### PR TITLE
Take out the ripple effect from the dropdown in static app bar

### DIFF
--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -433,6 +433,7 @@ class StaticAppBar extends Component {
                     anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
                     transformOrigin={{ horizontal: 'right', vertical: 'top' }}
                     getContentAnchorEl={null}
+                    transitionDuration={0}
                   >
                     <MenuItem key="placeholder" style={{ display: 'none' }} />
                     <Logged />


### PR DESCRIPTION
Fixes #2213 

Changes: Remove the timeDuration taken to open the dropDown in static app bar

Demo Link: https://pr-2220-fossasia-susi-web-chat.surge.sh

Screenshots of the change: [Add screenshots depicting the changes.]

![Screenshot 2019-06-06 at 11 28 19 PM](https://user-images.githubusercontent.com/31013104/59055130-cb6d3980-88b2-11e9-8803-92417137bde6.png)
