### PR TITLE
 Use 2 dialog confirmation approach for DeleteAccount #2225

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -39,7 +39,6 @@ import StaticAppBar from './components/StaticAppBar/StaticAppBar.react';
 import Footer from './components/Footer/Footer.react';
 import CookiePolicy from './components/CookiePolicy/CookiePolicy.react';
 import Admin from './components/Admin/Admin';
-import DeleteAccount from './components/Auth/DeleteAccount/DeleteAccount.react';
 
 class App extends Component {
   static propTypes = {
@@ -191,11 +190,6 @@ class App extends Component {
               <Route exact path="/logout" component={Logout} />
               <Route path="/admin" component={Admin} />
               <ProtectedRoute exact path="/settings" component={Settings} />
-              <ProtectedRoute
-                exact
-                path="/delete-account"
-                component={DeleteAccount}
-              />
               <Route exact path="/*:path(error-404|)" component={NotFound} />
             </Switch>
             {renderFooter}

--- a/src/__tests__/components/Auth/DeleteAccount/ConfirmDeleteAccount.js
+++ b/src/__tests__/components/Auth/DeleteAccount/ConfirmDeleteAccount.js
@@ -1,16 +1,16 @@
 import React from 'react';
-import DeleteAccountModal from '../../../components/Auth/DeleteAccount/DeleteAccountModal';
+import ConfirmDeleteAccount from '../../../components/Auth/DeleteAccount/ConfirmDeleteAccount';
 import { shallow } from 'enzyme';
 import { Provider } from 'react-redux';
 import configureMockStore from 'redux-mock-store';
 const mockStore = configureMockStore();
 const store = mockStore({});
 
-describe('<DeleteAccountModal />', () => {
-  it('render DeleteAccountModal without crashing', () => {
+describe('<ConfirmDeleteAccount />', () => {
+  it('render ConfirmDeleteAccount without crashing', () => {
     shallow(
       <Provider store={store}>
-        <DeleteAccountModal />
+        <ConfirmDeleteAccount />
       </Provider>,
     );
   });

--- a/src/components/Auth/DeleteAccount/DeleteAccount.react.js
+++ b/src/components/Auth/DeleteAccount/DeleteAccount.react.js
@@ -3,32 +3,26 @@ import PropTypes from 'prop-types';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 // Components
-import PasswordField from 'material-ui-password-field';
+import { PasswordField } from '../AuthStyles';
+import CloseButton from '../../shared/CloseButton';
+import DialogTitle from '@material-ui/core/DialogTitle';
+import DialogContent from '@material-ui/core/DialogContent';
 import CircularProgress from '@material-ui/core/CircularProgress';
 import Translate from '../../Translate/Translate.react';
 import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Button from '@material-ui/core/Button';
-import _Paper from '@material-ui/core/Paper';
 import { checkPassword, checkAccountPermission } from '../../../apis';
 import styled from 'styled-components';
 import uiActions from '../../../redux/actions/ui';
 
 const DeleteButton = styled(Button)`
   background-color: #ff0000;
+  margin-right: 0.625rem;
+  width: 10.375rem;
   color: white;
   :hover {
     background-color: #b20000;
-  }
-`;
-
-const Paper = styled(_Paper)`
-  margin: 5rem auto;
-  padding: 0.625rem;
-  text-align: center;
-  width: 25rem;
-  @media (max-width: 450px) {
-    width: 18.75rem;
   }
 `;
 
@@ -84,6 +78,15 @@ class DeleteAccount extends Component {
     }
   };
 
+  handleDialogClose = () => {
+    const { actions } = this.props;
+    this.setState({
+      password: '',
+      passwordError: false,
+    });
+    actions.closeModal();
+  };
+
   handleSubmit = event => {
     this.setState({ loading: true });
     const { actions, email } = this.props;
@@ -92,7 +95,7 @@ class DeleteAccount extends Component {
       .then(payload => {
         if (payload.accepted) {
           this.setState({ loading: false });
-          actions.openModal({ modalType: 'deleteAccount' });
+          actions.openModal({ modalType: 'confirmDeleteAccount' });
         }
       })
       .catch(error => {
@@ -103,17 +106,7 @@ class DeleteAccount extends Component {
       });
   };
 
-  handleCancel = event => {
-    this.props.history.push('/');
-  };
-
   render() {
-    const body = {
-      margin: '5rem auto',
-      padding: '0.625rem',
-      textAlign: 'center',
-    };
-
     const fieldStyle = {
       width: '16rem',
     };
@@ -124,55 +117,53 @@ class DeleteAccount extends Component {
     const { loading, password, validForm } = this.state;
     console.log(loading, 'Loading');
     return (
-      <div style={body}>
-        <Paper elevation={5}>
-          <h1 style={{ marginBottom: '30px' }}>Delete Account</h1>
-          <div>
-            <h4 style={{ fontWeight: 'normal' }}>
-              Please enter your password to confirm deletion
-            </h4>
-          </div>
-          <div>
-            <form onSubmit={this.handleSubmit}>
-              <div>
-                <FormControl error={this.passwordErrorMessage !== ''}>
-                  <PasswordField
-                    name="password"
-                    style={fieldStyle}
-                    value={password}
-                    onChange={this.handleChange}
-                    errorText={this.passwordErrorMessage}
-                  />
-                  <FormHelperText error={this.passwordErrorMessage !== ''}>
-                    {this.passwordErrorMessage}
-                  </FormHelperText>
-                </FormControl>
-              </div>
-              <div style={submitButton}>
-                <DeleteButton
-                  variant="contained"
-                  onClick={this.handleSubmit}
-                  disabled={!validForm}
-                  style={{ marginRight: '10px' }}
-                >
-                  {loading ? (
-                    <CircularProgress color="default" size={24} />
-                  ) : (
-                    <Translate text="Delete Account" />
-                  )}
-                </DeleteButton>
-                <Button
-                  variant="contained"
-                  color="primary"
-                  onClick={this.handleCancel}
-                >
-                  <Translate text="Cancel" />
-                </Button>
-              </div>
-            </form>
-          </div>
-        </Paper>
-      </div>
+      <React.Fragment>
+        <DialogTitle>
+          <Translate text="Delete Account" />
+          <CloseButton onClick={this.handleDialogClose} />
+        </DialogTitle>
+        <DialogContent>
+          <h4 style={{ fontWeight: 'normal' }}>
+            Please enter your password to confirm deletion
+          </h4>
+          <form onSubmit={this.handleSubmit}>
+            <div>
+              <FormControl error={this.passwordErrorMessage !== ''}>
+                <PasswordField
+                  name="password"
+                  style={fieldStyle}
+                  value={password}
+                  onChange={this.handleChange}
+                />
+                <FormHelperText error={this.passwordErrorMessage !== ''}>
+                  {this.passwordErrorMessage}
+                </FormHelperText>
+              </FormControl>
+            </div>
+            <div style={submitButton}>
+              <DeleteButton
+                variant="contained"
+                onClick={this.handleSubmit}
+                disabled={!validForm}
+                style={{ marginRight: '10px', width: '' }}
+              >
+                {loading ? (
+                  <CircularProgress color="default" size={24} />
+                ) : (
+                  <Translate text="Delete Account" />
+                )}
+              </DeleteButton>
+              <Button
+                variant="contained"
+                color="primary"
+                onClick={this.handleDialogClose}
+              >
+                <Translate text="Cancel" />
+              </Button>
+            </div>
+          </form>
+        </DialogContent>
+      </React.Fragment>
     );
   }
 }

--- a/src/components/Dialog/DialogSection.react.js
+++ b/src/components/Dialog/DialogSection.react.js
@@ -13,7 +13,8 @@ import ForgotPassword from '../Auth/ForgotPassword/ForgotPassword.react';
 import RemoveDeviceDialog from '../Settings/DevicesTab/RemoveDeviceDialog';
 import ThemeChanger from '../Settings/ThemeChanger';
 import { DialogContainer } from '../shared/Container';
-import DeleteAccountModal from '../Auth/DeleteAccount/DeleteAccountModal.react';
+import DeleteAccount from '../Auth/DeleteAccount/DeleteAccount.react';
+import ConfirmDeleteAccount from '../Auth/DeleteAccount/ConfirmDeleteAccount.react';
 
 const DialogData = {
   share: { Component: Share, size: 'xs' },
@@ -22,7 +23,8 @@ const DialogData = {
   forgotPassword: { Component: ForgotPassword, size: 'sm' },
   themeChange: { Component: ThemeChanger, size: 'md' },
   tour: { Component: Tour, size: 'sm' },
-  deleteAccount: { Component: DeleteAccountModal, size: 'sm' },
+  deleteAccount: { Component: DeleteAccount, size: 'sm' },
+  confirmDeleteAccount: { Component: ConfirmDeleteAccount, size: 'sm' },
   noComponent: { Component: null, size: false },
   deleteDevice: { Component: RemoveDeviceDialog, size: 'sm' },
 };
@@ -44,7 +46,7 @@ const DialogSection = props => {
   };
 
   const { size, Component } = getDialog();
-  const addPadding = modalType !== 'deleteAccount';
+  const addPadding = modalType !== 'confirmDeleteAccount';
   return (
     <div>
       <Dialog

--- a/src/components/Settings/AccountTab.react.js
+++ b/src/components/Settings/AccountTab.react.js
@@ -1,7 +1,6 @@
 import React from 'react';
 import Translate from '../Translate/Translate.react';
 import Avatar from './Avatar';
-import { Link as _Link } from 'react-router-dom';
 import { connect } from 'react-redux';
 import SettingsTabWrapper from './SettingsTabWrapper';
 import OutlinedInput from '@material-ui/core/OutlinedInput';
@@ -50,16 +49,7 @@ const DangerButton = styled(Button)`
   background-color: #fafbfc;
   color: #cb2431;
   &:hover {
-    background-color: #cb2431;
-    border-color: rgba(27, 31, 35, 0.5);
-    color: #fff;
-  }
-`;
-
-const Link = styled(_Link)`
-  color: #cb2431;
-  font-weight: 600;
-  &:hover {
+    background-color: #ff0000;
     color: #fff;
   }
 `;
@@ -284,6 +274,7 @@ class AccountTab extends React.Component {
       settingSave,
     } = this.state;
     const {
+      actions,
       email,
       timeZone: _timeZone,
       prefLanguage: _prefLanguage,
@@ -411,8 +402,11 @@ class AccountTab extends React.Component {
             <Translate text="Once you delete account, there is no going back. Please be certain." />
           </div>
           <div>
-            <DangerButton variant="contained">
-              <Link to="/delete-account">Delete</Link>
+            <DangerButton
+              variant="contained"
+              onClick={() => actions.openModal({ modalType: 'deleteAccount' })}
+            >
+              Delete
             </DangerButton>
           </div>
         </DangerContainer>


### PR DESCRIPTION
Fixes #2225 

Changes:

- Use 2 dialog confirmation approach for DeleteAccount
- Remove separate page

Demo Link: https://pr-2226-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
<img width="940" alt="Screenshot 2019-06-07 at 8 32 02 PM" src="https://user-images.githubusercontent.com/18073126/59113787-5a398f00-8963-11e9-8105-2a62d1c3b585.png">


