### PR TITLE
Separate privacy and terms page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -105,6 +105,9 @@ class App extends Component {
       '/blog',
       '/devices',
       '/skills',
+      '/privacy',
+      '/terms',
+      '/contact',
     ];
     const renderAppBar =
       pathname !== '/chat' ? <StaticAppBar showPageTabs={true} /> : null;

--- a/src/components/Privacy/Privacy.react.js
+++ b/src/components/Privacy/Privacy.react.js
@@ -2,7 +2,18 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { Header } from '../shared/About';
 import { scrollToTopAnimation } from '../../utils/animateScroll';
-import '../Terms/Terms.css';
+import styled from 'styled-components';
+
+const H1 = styled.h1`
+  margin-top: 5rem;
+  margin-bottom: 1.5rem;
+  text-align: center;
+`;
+
+const HomeDiv = styled.div`
+  width: 75%;
+  margin: 0rem auto;
+`;
 
 const Privacy = props => {
   // Adding title tag to page
@@ -13,284 +24,137 @@ const Privacy = props => {
   document.body.style.setProperty('background-image', 'none');
   return (
     <div>
-      <Header title="Privacy" subtitle="Privacy Policy for SUSI" />
-      <div className="section">
-        <div className="section-container">
-          <div className="terms-list">
-            <br />
-            <br />
-            <h2>Welcome to SUSI!</h2>
-            <p>
-              Thanks for using our products and services (“Services”). The
-              Services are provided by SUSI Inc. (“SUSI”), located at 93 Mau
-              Than, Can Tho City, Viet Nam. By using our Services, you are
-              agreeing to these terms. Please read them carefully.
-            </p>
-            <h2>Using our Services</h2>
-            <p>
-              You must follow any policies made available to you within the
-              Services.
-              <br />
-              <br />
-              Don’t misuse our Services. For example, don’t interfere with our
-              Services or try to access them using a method other than the
-              interface and the instructions that we provide. You may use our
-              Services only as permitted by law, including applicable export and
-              re-export control laws and regulations. We may suspend or stop
-              providing our Services to you if you do not comply with our terms
-              or policies or if we are investigating suspected misconduct.
-              <br />
-              <br />
-              Using our Services does not give you ownership of any intellectual
-              property rights in our Services or the content you access. You may
-              not use content from our Services unless you obtain permission
-              from its owner or are otherwise permitted by law. These terms do
-              not grant you the right to use any branding or logos used in our
-              Services. Don’t remove, obscure, or alter any legal notices
-              displayed in or along with our Services.
-              <br />
-              <br />
-              Our Services display some content that is not SUSI’s. This content
-              is the sole responsibility of the entity that makes it available.
-              We may review content to determine whether it is illegal or
-              violates our policies, and we may remove or refuse to display
-              content that we reasonably believe violates our policies or the
-              law. But that does not necessarily mean that we review content, so
-              please don’t assume that we do.
-              <br />
-              <br />
-              In connection with your use of the Services, we may send you
-              service announcements, administrative messages, and other
-              information. You may opt out of some of those communications.
-              <br />
-              <br />
-              Some of our Services are available on mobile devices. Do not use
-              such Services in a way that distracts you and prevents you from
-              obeying traffic or safety laws.
-              <br />
-              <br />
-            </p>
-            <h2>Your SUSI Account</h2>
-            <p>
-              You may need a SUSI Account in order to use some of our Services.
-              You may create your own SUSI Account, or your SUSI Account may be
-              assigned to you by an administrator, such as your employer or
-              educational institution. If you are using a SUSI Account assigned
-              to you by an administrator, different or additional terms may
-              apply and your administrator may be able to access or disable your
-              account.
-              <br />
-              <br />
-              To protect your SUSI Account, keep your password confidential. You
-              are responsible for the activity that happens on or through your
-              SUSI Account. Try not to reuse your SUSI Account password on
-              third-party applications. If you learn of any unauthorized use of
-              your password or SUSI Account, change your password and take
-              measures to secure your account.
-              <br />
-              <br />
-            </p>
-            <h2>Privacy and Copyright Protection</h2>
-            <p>
-              SUSI’s privacy policies ensure that your personal data is safe and
-              protected. By using our Services, you agree that SUSI can use such
-              data in accordance with our privacy policies.
-              <br />
-              <br />
-              We respond to notices of alleged copyright infringement and
-              terminate accounts of repeat infringers. If you think somebody is
-              violating your copyrights and want to notify us, you can find
-              information about submitting notices and SUSI’s policy about
-              responding to notices on our website.
-              <br />
-              <br />
-            </p>
-            <h2>Your Content in our Services</h2>
-            <p>
-              Some of our Services allow you to upload, submit, store, send or
-              receive content. You retain ownership of any intellectual property
-              rights that you hold in that content. In short, what belongs to
-              you stays yours.
-              <br />
-              <br />
-              When you upload, submit, store, send or receive content to or
-              through our Services, you give SUSI (and those we work with) a
-              worldwide license to use, host, store, reproduce, modify, create
-              derivative works (such as those resulting from translations,
-              adaptations or other changes we make so that your content works
-              better with our Services), communicate, publish, publicly perform,
-              publicly display and distribute such content. The rights you grant
-              in the license are for the limited purpose of operating,
-              promoting, and improving our Services, and to develop new ones.
-              This license continues even if you stop using our Services (for
-              example, for a business listing you have added to SUSI Maps). Some
-              Services may offer you ways to access and remove content that has
-              been provided to that Service. Also, in some of our Services,
-              there are terms or settings that narrow the scope of our use of
-              the content submitted in those Services. Make sure you have the
-              necessary rights to a grant license for any content that you
-              submit to our Services.
-              <br />
-              <br />
-              If you have a SUSI Account, we may display your Profile name,
-              Profile photo, and actions you take on SUSI or on third-party
-              applications connected to your SUSI Account in our Services,
-              including displaying in ads and other commercial contexts. We will
-              respect the choices you make to limit sharing or visibility
-              settings in your SUSI Account.
-              <br />
-              <br />
-            </p>
-            <h2>About Software in our Services</h2>
-            <p>
-              When a Service requires or includes downloadable software, the
-              software may update automatically on your device once a new
-              version or feature is available. Some Services may let you adjust
-              your automatic update settings.
-              <br />
-              <br />
-              SUSI gives you a personal, worldwide, royalty-free, non-assignable
-              and non-exclusive license to use the software provided to you by
-              SUSI as part of the Services. This license is for the sole purpose
-              of enabling you to use and enjoy the benefit of the Services as
-              provided by SUSI, in the manner permitted by these terms.
-              <br />
-              <br />
-              Most of our services are offered through Free Software and/or Open
-              Source Software. You may copy, modify, distribute, sell, or lease
-              these applications and share the source code of that software as
-              stated in the License Agreement provided with the Software.
-              <br />
-              <br />
-            </p>
-            <h2>Modifying and Terminating our Services</h2>
-            <p>
-              We are constantly changing and improving our Services. We may add
-              or remove functionalities or features, and we may suspend or stop
-              a Service altogether.
-              <br />
-              <br />
-              You can stop using our Services at any time. SUSI may also stop
-              providing Services to you, or add or create new limits to our
-              Services at any time.
-              <br />
-              <br />
-              We believe that you own your data and preserving your access to
-              such data is important. If we discontinue a Service, where
-              reasonably possible, we will give you reasonable advance notice
-              and a chance to get information out of that Service.
-              <br />
-              <br />
-            </p>
-            <h2>Our Warranties and Disclaimers</h2>
-            <p>
-              We provide our Services using a reasonable level of skill and care
-              and we hope that you will enjoy using them. But there are certain
-              things that we don’t promise about our Services.
-              <br />
-              <br />
-              Other than as expressly set out in these terms or additional
-              terms, neither SUSI nor its suppliers or distributors make any
-              specific promises about the Services. For example, we don’t make
-              any commitments about the content within the Services, the
-              specific functions of the Services, or their reliability,
-              availability, or ability to meet your needs. We provide the
-              Services “as is”.
-              <br />
-              <br />
-              Some jurisdictions provide for certain warranties, like the
-              implied warranty of merchantability, fitness for a particular
-              purpose and non-infringement. To the extent permitted by law, we
-              exclude all warranties.
-              <br />
-              <br />
-            </p>
-            <h2>Liability for our Services</h2>
-            <p>
-              When permitted by law, SUSI, and SUSI’s suppliers and
-              distributors, will not be responsible for lost profits, revenues,
-              or data, financial losses or indirect, special, consequential,
-              exemplary, or punitive damages.
-              <br />
-              <br />
-              To the extent permitted by law, the total liability of SUSI, and
-              its suppliers and distributors, for any claims under these terms,
-              including for any implied warranties, is limited to the amount you
-              paid us to use the Services (or, if we choose, to supplying you
-              the Services again).
-              <br />
-              <br />
-              In all cases, SUSI, and its suppliers and distributors will not be
-              liable for any loss or damage that is not reasonably foreseeable.
-              <br />
-              <br />
-              We recognize that in some countries, you might have legal rights
-              as a consumer. If you are using the Services for a personal
-              purpose, then nothing in these terms or any additional terms
-              limits any consumer legal rights which may not be waived by
-              contract.
-              <br />
-              <br />
-            </p>
-            <h2>Business uses of our Services</h2>
-            <p>
-              If you are using our Services on behalf of a business, that
-              business accepts these terms. It will hold harmless and indemnify
-              SUSI and its affiliates, officers, agents, and employees from any
-              claim, suit or action arising from or related to the use of the
-              Services or violation of these terms, including any liability or
-              expense arising from claims, losses, damages, suits, judgments,
-              litigation costs and attorneys’ fees.
-              <br />
-              <br />
-            </p>
-            <h2>About these Terms</h2>
-            <p>
-              We may modify these terms or any additional terms that apply to a
-              Service to, for example, reflect changes to the law or changes to
-              our Services. You should look at the terms regularly. We’ll post
-              notice of modifications to these terms on the page. We’ll post
-              notice of modified additional terms in the applicable Service.
-              Changes will not apply retroactively and will become effective no
-              sooner than fourteen days after they are posted. However,changes
-              addressing new functions for a Service or changes made for legal
-              reasons will be effective immediately. If you do not agree to the
-              modified terms for a Service, you should discontinue your use of
-              that Service.
-              <br />
-              <br />
-              If there is a conflict between these terms and the additional
-              terms, the additional terms will control for that conflict.
-              <br />
-              These terms control the relationship between SUSI and you. They do
-              not create any third party beneficiary rights.
-              <br />
-              <br />
-              If you do not comply with these terms, and we don’t take action
-              right away, doesn’t mean that we are giving up any rights that we
-              may have (such as taking action in the future).
-              <br />
-              <br />
-              If it turns out that a particular term is not enforceable, will
-              not affect any other terms.
-              <br />
-              <br />
-              You agree that the laws of Can Tho, Viet Nam will apply to any
-              disputes arising out of or relating to these terms or the
-              Services. All claims arising out of or relating to these terms or
-              the services will be litigated exclusively in the courts of Can
-              Tho City, Viet Nam, and you and SUSI consent to personal
-              jurisdiction in those courts.
-              <br />
-              <br />
-              For information about how to contact SUSI, please visit our
-              contact page.
-              <br />
-              <br />
-            </p>
-          </div>
+      <Header title="Privacy" subtitle="Privacy Policy for SUSI.AI" />
+      <HomeDiv>
+        <H1>
+          When you use our services, you’re trusting us with your information.
+          We understand this is a big responsibility and we work hard to protect
+          your information and put you in control.
+        </H1>
+        <div>
+          <p>
+            This Privacy Policy is meant to help you understand what information
+            we collect, why we collect it, and how you can update, manage,
+            export, and delete your information. We build a range of services
+            that help millions of people daily to explore and interact with the
+            world in new ways. Our services include:
+            <ul>
+              <li>SUSI.AI Smart Speaker</li>
+              <li>SUSI.AI Chat</li>
+              <li>Custom Chatbots</li>
+              <li>Personalised Skills</li>
+            </ul>
+          </p>
+          <p>
+            You can use our services in a variety of ways to manage your
+            privacy. For example, you can sign up for a SUSI.AI Account if you
+            want to create and manage content like skills or chatbots, or have
+            an extraordinary experience of SUSI.AI Smart Speaker. You can also
+            use many SUSI.AI services when you’re signed out or without creating
+            an account at all, like chatting with SUSI.AI on web or app. And
+            across our services, you can adjust your privacy settings to control
+            what we collect and how your information is used.
+          </p>
+          <h2>
+            We want you to understand the types of information we collect as you
+            use our services
+          </h2>
+          <p>
+            We collect information to provide better services to all our users —
+            from figuring out basic stuff like which skils you have rated to
+            more complex things like locating your SUSI.AI smart speaker. The
+            information SUSI.AI collects, and how that information is used,
+            depends on how you use our services and how you manage your privacy
+            controls. When you’re signed in, we also collect information that we
+            store with your SUSI.AI Account, which we treat as personal
+            information.
+          </p>
+          <h2>Things you create or provide to us</h2>
+          <p>
+            When you create a SUSI.AI Account, you provide us with personal
+            information that includes your name and a password. You can also
+            choose to add a phone number, Smart Speaker information or upload
+            photo to your account.
+          </p>
+          <p>
+            We also collect the content you create, upload or receive from
+            others when using our services. This includes things like skills and
+            chatbots you create and feeback you receive on your skills, profile
+            photo you upload, and comments and rating you make on existing
+            skills.
+          </p>
+          <h2>Information we collect as you use our services</h2>
+          <p>
+            We collect information about the SUSI.AI Smart speaker devices you
+            have connected. We collect information about the interaction of your
+            SUSI.AI smart speaker devices with our services, including IP
+            address, crash reports, system activity, and the date, time, and
+            referrer URL of your request.
+          </p>
+          <p>
+            We collect this information when a SUSI.AI service on your device
+            contacts our servers — for example, when you use a skill on your
+            device. If you’re using an Android device with SUSI.AI smart
+            speaker, your device periodically contacts SUSI.AI servers to
+            provide information about your device and connection to our
+            services. This information includes things like your device name,
+            crash reports, and location of your device.
+          </p>
+          <p>
+            We use various technologies to collect and store information,
+            including cookies, local storage, such as browser web storage or
+            application data caches, databases, and server logs.
+          </p>
+          <h2>Managing, reviewing, and updating your information</h2>
+          <p>
+            When you’re signed in, you can always review and update information
+            by visiting the services you use. For example, Dashboard and
+            Settings are both designed to help you manage specific types of
+            content you’ve saved with SUSI.AI.
+          </p>
+          <h2>Deleting your information</h2>
+          <p>
+            To delete your information, you can:
+            <ul>
+              <li>Request an admin to delete your skill</li>
+              <li>Delete your chatbots</li>
+              <li>Delete your entire SUSI.AI account</li>
+            </ul>
+          </p>
+          <h2>
+            We build security into our services to protect your information
+          </h2>
+          <p>
+            SUSI.AI is built with strong security features that continuously
+            protect your information. The insights we gain from maintaining our
+            services help us detect and automatically block security threats
+            from ever reaching you. And if we do detect something risky that we
+            think you should know about, we’ll notify you and help guide you
+            through steps to stay better protected.
+          </p>
+          <p>
+            We work hard to protect you and SUSI.AI from unauthorized access,
+            alteration, disclosure, or destruction of information we hold,
+            including:
+            <ul>
+              <li>
+                We use encryption to keep your data private while in transit
+              </li>
+              <li>
+                We review our information collection, storage, and processing
+                practices, including physical security measures, to prevent
+                unauthorized access to our systems
+              </li>
+              <li>
+                We restrict access to personal information to SUSI.AI
+                developers. Anyone with this access is subject to strict
+                contractual confidentiality obligations and may be disciplined
+                or terminated if they fail to meet these obligations.
+              </li>
+            </ul>
+          </p>
         </div>
-      </div>
+      </HomeDiv>
     </div>
   );
 };


### PR DESCRIPTION
Fixes #2212 
Changes: Added content for Privacy page similar to Google's privacy page.(https://policies.google.com/privacy?hl=en-US)

Demo Link: https://pr-2251-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 

![Screenshot 2019-06-10 at 11 34 35 PM](https://user-images.githubusercontent.com/31013104/59216016-57939f80-8bd8-11e9-9d64-c66846a78166.png)
