### PR TITLE
Fix Bugs in Skill Feedback, Drafts and Rating Popover

### DIFF
--- a/src/components/cms/BotBuilder/BotWizard.js
+++ b/src/components/cms/BotBuilder/BotWizard.js
@@ -20,7 +20,7 @@ import ChevronLeft from '@material-ui/icons/ChevronLeft';
 import ChevronRight from '@material-ui/icons/ChevronRight';
 import getQueryStringValue from '../../../utils/getQueryStringValue';
 import avatars from '../../../utils/avatars';
-import { storeDraft, updateSkill } from '../../../apis/index';
+import { storeDraft, updateSkill, readDraft } from '../../../apis/index';
 import './BotBuilder.css';
 import createActions from '../../../redux/actions/create';
 import SkillCreator from '../SkillCreator/SkillCreator';
@@ -194,11 +194,8 @@ class BotWizard extends React.Component {
 
   getDraftBotDetails = id => {
     const { actions } = this.props;
-    actions
-      .readDraft({ id })
-      .then(payload => {
-        console.log('Read draft');
-      })
+    readDraft({ id })
+      .then(payload => {})
       .catch(error => {
         actions.openSnackBar({
           snackBarMessage: "Couldn't get your drafts. Please reload the page.",

--- a/src/components/cms/SkillCardList/SkillCardList.js
+++ b/src/components/cms/SkillCardList/SkillCardList.js
@@ -268,7 +268,7 @@ function createListCard(
                   <Link
                     key={el}
                     to={{
-                      pathname: `/${skill.group}/${skill.skillTag}/${skill.language}/feedbacks`,
+                      pathname: `/skills/${skill.group}/${skill.skillTag}/${skill.language}/feedbacks`,
                     }}
                   >
                     <Ratings

--- a/src/components/cms/SkillFeedbackPage/SkillFeedbackPage.js
+++ b/src/components/cms/SkillFeedbackPage/SkillFeedbackPage.js
@@ -4,6 +4,7 @@ import { Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import skillActions from '../../../redux/actions/skill';
+import uiActions from '../../../redux/actions/ui';
 import PropTypes from 'prop-types';
 
 import ListItem from '@material-ui/core/ListItem';
@@ -24,7 +25,6 @@ import FormControl from '@material-ui/core/FormControl';
 import FormHelperText from '@material-ui/core/FormHelperText';
 import Input from '@material-ui/core/Input';
 import CircularProgress from '@material-ui/core/CircularProgress';
-import AuthorSkills from '../AuthorSkills/AuthorSkills';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import Delete from '@material-ui/icons/Delete';
 import EditBtn from '@material-ui/icons/BorderColor';
@@ -73,7 +73,6 @@ class SkillFeedbackPage extends Component {
       openDeleteModal: false,
       errorText: '',
       loading: true,
-      showAuthorSkills: false,
       currentPage: 1,
       currentRecords: [],
       anchorEl: null,
@@ -272,14 +271,6 @@ class SkillFeedbackPage extends Component {
     this.toggleDeleteModal();
   };
 
-  toggleAuthorSkills = () => {
-    if (this.author) {
-      this.setState(prevState => ({
-        showAuthorSkills: !prevState.showAuthorSkills,
-      }));
-    }
-  };
-
   handleMenuOpen = event => {
     this.setState({
       anchorEl: event.currentTarget,
@@ -292,10 +283,13 @@ class SkillFeedbackPage extends Component {
     });
   };
 
+  openAuthorSkills = () => {
+    this.props.actions.openModal({ modalType: 'authorSkills' });
+  };
+
   render() {
     const {
       currentPage,
-      showAuthorSkills,
       errorText,
       openEditDialog,
       openDeleteModal,
@@ -536,7 +530,7 @@ class SkillFeedbackPage extends Component {
                     by{' '}
                     <span
                       className="feedback-author"
-                      onClick={this.toggleAuthorSkills}
+                      onClick={this.openAuthorSkills}
                     >
                       {author}
                     </span>
@@ -696,15 +690,6 @@ class SkillFeedbackPage extends Component {
           </DialogContent>
           <DialogActions>{deleteActions}</DialogActions>
         </Dialog>
-        <div>
-          <AuthorSkills
-            ref={c => {
-              this.author = c;
-            }}
-            open={showAuthorSkills}
-            requestClose={this.toggleAuthorSkills}
-          />
-        </div>
       </div>
     );
   }
@@ -742,7 +727,7 @@ function mapStateToProps(store) {
 
 function mapDispatchToProps(dispatch) {
   return {
-    actions: bindActionCreators(skillActions, dispatch),
+    actions: bindActionCreators({ ...skillActions, ...uiActions }, dispatch),
   };
 }
 


### PR DESCRIPTION
Fixes #2318 , #2317 , #2322 
Changes: 
Now clicking on `show all reviews` in Rating Popover redirects to correct link.
Corrected the error in calling the draft API.
Corrected the display of author skills in Skill Feedback page.

Demo Link: https://pr-2323-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
![Screenshot 2019-06-18 at 8 20 47 PM](https://user-images.githubusercontent.com/31013104/59694626-947a1a80-9206-11e9-82c7-f8017eb6d7cd.png)

