### PR TITLE
Reimplement App Navigation Menu #2345

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -204,11 +204,11 @@ class App extends Component {
                 path="/skills/botbuilder"
                 component={BotBuilderWrap}
               />
-              <Route exact path="/devices" component={Devices} />
-              <Route exact path="/team" component={Team} />
-              <Route exact path="/blog" component={Blog} />
-              <Route exact path="/contact" component={Contact} />
-              <Route exact path="/support" component={Support} />
+              <Route exact path="/about/devices" component={Devices} />
+              <Route exact path="/about/team" component={Team} />
+              <Route exact path="/about/blog" component={Blog} />
+              <Route exact path="/about/contact" component={Contact} />
+              <Route exact path="/about/support" component={Support} />
               <Route exact path="/terms" component={Terms} />
               <Route exact path="/privacy" component={Privacy} />
               <Route exact path="/verify-account" component={VerifyAccount} />

--- a/src/__tests__/components/StaticAppBar/LeftMenu.js
+++ b/src/__tests__/components/StaticAppBar/LeftMenu.js
@@ -1,0 +1,16 @@
+import React from 'react';
+import LeftMenu from '../../../components/StaticAppBar/LeftMenu';
+import { shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+const mockStore = configureMockStore();
+const store = mockStore({});
+describe('<LeftMenu />', () => {
+  it('renders LeftMenu without crashing', () => {
+    shallow(
+      <Provider store={store}>
+        <LeftMenu />
+      </Provider>,
+    );
+  });
+});

--- a/src/__tests__/components/StaticAppBar/TopMenu.js
+++ b/src/__tests__/components/StaticAppBar/TopMenu.js
@@ -1,0 +1,17 @@
+import React from 'react';
+import TopMenu from '../../../components/StaticAppBar/TopMenu';
+import { shallow } from 'enzyme';
+import { Provider } from 'react-redux';
+import configureMockStore from 'redux-mock-store';
+const mockStore = configureMockStore();
+const store = mockStore({});
+
+describe('<TopMenu />', () => {
+  it('renders TopMenu without crashing', () => {
+    shallow(
+      <Provider store={store}>
+        <TopMenu />
+      </Provider>,
+    );
+  });
+});

--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -63,6 +63,12 @@ class Admin extends Component {
       });
   }
 
+  componentDidUpdate(prevProps) {
+    if (this.props.location !== prevProps.location) {
+      this.initilizeData();
+    }
+  }
+
   initilizeData = () => {
     let endPath = this.props.location.pathname.split('/')[2];
     let heading = 'Admin';

--- a/src/components/Footer/Footer.react.js
+++ b/src/components/Footer/Footer.react.js
@@ -31,7 +31,7 @@ const Footer = () => {
                 <Link to="/">Overview</Link>
               </li>
               <li>
-                <Link to="/blog">Blog</Link>
+                <Link to="/about/blog">Blog</Link>
               </li>
               <li>
                 <a href={urls.API_URL}>API</a>
@@ -51,7 +51,7 @@ const Footer = () => {
               <Link to="/terms">Terms</Link>
             </li>
             <li>
-              <Link to="/contact">Contact</Link>
+              <Link to="/about/contact">Contact</Link>
             </li>
           </ul>
         </div>

--- a/src/components/StaticAppBar/LeftMenu.js
+++ b/src/components/StaticAppBar/LeftMenu.js
@@ -1,0 +1,108 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import LINKS from './constants';
+import ListItemIcon from '@material-ui/core/ListItemIcon';
+import ListItemText from '@material-ui/core/ListItemText';
+import Divider from '@material-ui/core/Divider';
+import ListItem from '@material-ui/core/ListItem';
+import List from '@material-ui/core/List';
+import Link from '../shared/Link';
+import ExpandMore from '@material-ui/icons/ExpandMore';
+import ExpandLess from '@material-ui/icons/ExpandLess';
+import Collapse from '@material-ui/core/Collapse';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+
+class LeftMenu extends React.Component {
+  static propTypes = {
+    isAdmin: PropTypes.bool,
+    accessToken: PropTypes.string,
+    handleDrawerClose: PropTypes.func,
+  };
+  state = {};
+
+  handleClick = label => {
+    this.setState({ [label]: !this.state[label] });
+  };
+
+  render() {
+    const { isAdmin, accessToken, handleDrawerClose } = this.props;
+    const menuLinks = LINKS(accessToken, isAdmin).map(
+      ({ label = '', Icon = null, url, sublinks = [] }) => {
+        if (label === '') {
+          return null;
+        } else if (_.isEmpty(sublinks)) {
+          return (
+            <React.Fragment key={label}>
+              <ListItem button key={label} component={Link} to={url}>
+                {Icon && (
+                  <ListItemIcon>
+                    <Icon />
+                  </ListItemIcon>
+                )}
+                <ListItemText primary={label} />
+              </ListItem>
+              <Divider />
+            </React.Fragment>
+          );
+        }
+        return (
+          <React.Fragment key={label}>
+            <ListItem
+              button={true}
+              key={label}
+              component={Link}
+              onClick={() => this.handleClick(label)}
+            >
+              {Icon && (
+                <ListItemIcon>
+                  <Icon />
+                </ListItemIcon>
+              )}
+              <ListItemText primary={label} />
+              {this.state[label] ? <ExpandLess /> : <ExpandMore />}
+            </ListItem>
+            <Collapse
+              in={this.state[label]}
+              timeout="auto"
+              unmountOnExit={true}
+            >
+              {sublinks.map(({ label, url, Icon }) => {
+                return (
+                  <ListItem
+                    button={true}
+                    key={label}
+                    component={Link}
+                    to={url}
+                    onClick={handleDrawerClose}
+                  >
+                    {Icon && (
+                      <ListItemIcon>
+                        <Icon />
+                      </ListItemIcon>
+                    )}
+                    <ListItemText primary={label} />
+                  </ListItem>
+                );
+              })}
+            </Collapse>
+            <Divider />
+          </React.Fragment>
+        );
+      },
+    );
+    return <List>{menuLinks}</List>;
+  }
+}
+
+function mapStateToProps(store) {
+  return {
+    isAdmin: store.app.isAdmin,
+    accessToken: store.app.accessToken,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null,
+)(LeftMenu);

--- a/src/components/StaticAppBar/StaticAppBar.react.js
+++ b/src/components/StaticAppBar/StaticAppBar.react.js
@@ -10,33 +10,28 @@ import AppBar from '@material-ui/core/AppBar';
 import IconButton from '@material-ui/core/IconButton';
 import MenuItem from '@material-ui/core/MenuItem';
 import MenuIcon from '@material-ui/icons/Menu';
-import Menu from '@material-ui/core/Menu';
 import Translate from '../Translate/Translate.react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import CircleImage from '../CircleImage/CircleImage';
-import Info from '@material-ui/icons/Info';
 import { bindActionCreators } from 'redux';
 import uiActions from '../../redux/actions/ui';
 import Link from '../shared/Link';
 import MoreVertIcon from '@material-ui/icons/MoreVert';
 import SignUpIcon from '@material-ui/icons/AccountCircle';
 import Settings from '@material-ui/icons/Settings';
-import Chat from '@material-ui/icons/Chat';
-import Dashboard from '@material-ui/icons/Dashboard';
 import Exit from '@material-ui/icons/ExitToApp';
 import susiWhite from '../../images/susi-logo-white.png';
-import Extension from '@material-ui/icons/Extension';
-import Assessment from '@material-ui/icons/Assessment';
-import ListIcon from '@material-ui/icons/List';
-import PeopleIcon from '@material-ui/icons/People';
-import BlogIcon from '@material-ui/icons/ChromeReaderMode';
-import DevicesIcon from '@material-ui/icons/Devices';
-import InfoIcon from '@material-ui/icons/Info';
-import SupportIcon from '@material-ui/icons/Face';
-import ListItem from '@material-ui/core/ListItem';
-import List from '@material-ui/core/List';
 import Slide from '@material-ui/core/Slide';
 import useScrollTrigger from '@material-ui/core/useScrollTrigger';
+import TopMenu from './TopMenu';
+import LeftMenu from './LeftMenu';
+import CssBaseline from '@material-ui/core/CssBaseline';
+import Popper from '@material-ui/core/Popper';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import Fade from '@material-ui/core/Fade';
+import Paper from '@material-ui/core/Paper';
+import throttle from 'lodash.throttle';
+
 import {
   StyledIconButton,
   UserDetail,
@@ -52,34 +47,6 @@ const BurgerMenuContainer = styled.div`
   }
 `;
 
-const NavLinkContainer = styled.div`
-  display: block;
-  @media (max-width: 800px) {
-    display: none;
-  }
-`;
-
-const NavLink = styled.a`
-  padding: 0px 25px 7px;
-  font: 500;
-  margin: 0 2px;
-  text-transform: none;
-  text-decoration: none;
-  word-spacing: 2px;
-  vertical-align: bottom;
-  color: #ffffff;
-  :hover {
-    color: #ffffff;
-  }
-  ${props =>
-    props.isActive &&
-    css`
-      border-bottom: 2px solid #ffffff;
-      font-weight: 700;
-      padding: 0px 25px 12px;
-    `};
-`;
-
 const TopRightMenuContainer = styled.div`
   display: flex;
   justify-content: center;
@@ -88,51 +55,11 @@ const TopRightMenuContainer = styled.div`
   margin-top: 1px;
 `;
 
-const topLinks = [
-  {
-    label: 'Overview',
-    url: '/',
-    icon: <InfoIcon />,
-  },
-  {
-    label: 'Devices',
-    url: '/devices',
-    icon: <DevicesIcon />,
-  },
-  {
-    label: 'Blog',
-    url: '/blog',
-    icon: <BlogIcon />,
-  },
-  {
-    label: 'Team',
-    url: '/team',
-    icon: <PeopleIcon />,
-  },
-  {
-    label: 'Support',
-    url: '/support',
-    icon: <SupportIcon />,
-  },
-];
-
-const navLinks = topLinks.map((link, index) => {
-  return (
-    <NavLink
-      isActive={window.location.pathname === link.url}
-      key={link.label}
-      href={link.url}
-    >
-      {link.label}
-    </NavLink>
-  );
-});
-
-const TopMenu = () => (
-  <div style={{ marginLeft: '2rem' }}>
-    <NavLinkContainer>{navLinks}</NavLinkContainer>
-  </div>
-);
+const StyledDrawer = styled(({ className, ...props }) => (
+  <Drawer {...props} classes={{ paper: className }} />
+))`
+  width: 10rem;
+`;
 
 const HideOnScroll = ({ children }) => {
   const trigger = useScrollTrigger();
@@ -168,6 +95,7 @@ class StaticAppBar extends Component {
       anchorEl: null,
       drawerOpen: false,
     };
+    this.throttledMenuClose = throttle(this.handleMenuClose, 400);
   }
 
   handleDrawerToggle = () => {
@@ -192,115 +120,40 @@ class StaticAppBar extends Component {
     actions.openModal({ modalType: 'login' });
   };
 
+  componentDidMount() {
+    window.addEventListener('scroll', this.throttledMenuClose);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('scroll', this.throttledMenuClose);
+  }
+
   render() {
     const {
       showPageTabs,
       accessToken,
       email,
       userName,
-      isAdmin,
       avatarImgThumbnail,
       history,
     } = this.props;
     const { anchorEl, drawerOpen } = this.state;
     const open = Boolean(anchorEl);
-    const menuLinks = topLinks.map(link => {
-      return (
-        <ListItem
-          button
-          key={link.label}
-          component={Link}
-          to={link.url}
-          onClick={this.handleDrawerToggle}
-        >
-          <ListItemIcon>{link.icon}</ListItemIcon>
-          <ListItemText primary={link.label} />
-        </ListItem>
-      );
-    });
-    // Check the path to show or not to show top bar left menu
 
     const Logged = props => (
       <div>
         {accessToken && (
-          <Link to="/skills/dashboard">
+          <Link to="/settings">
             <MenuItem onClick={this.handleMenuClose}>
               <ListItemIcon>
-                <Assessment />
+                <Settings />
               </ListItemIcon>
               <ListItemText>
-                <Translate text="Dashboard" />
+                <Translate text="Settings" />
               </ListItemText>
             </MenuItem>
           </Link>
         )}
-
-        <Link to="/chat">
-          <MenuItem>
-            <ListItemIcon>
-              <Chat />
-            </ListItemIcon>
-            <ListItemText>
-              <Translate text="Chat" />
-            </ListItemText>
-          </MenuItem>
-        </Link>
-        <Link to="/skills">
-          <MenuItem onClick={this.handleMenuClose}>
-            <ListItemIcon>
-              <Dashboard />
-            </ListItemIcon>
-            <ListItemText>
-              <Translate text="Skills" />
-            </ListItemText>
-          </MenuItem>
-        </Link>
-        {accessToken && (
-          <div>
-            <Link to="/skills/botbuilder">
-              <MenuItem onClick={this.handleMenuClose}>
-                <ListItemIcon>
-                  <Extension />
-                </ListItemIcon>
-                <ListItemText>
-                  <Translate text="Botbuilder" />
-                </ListItemText>
-              </MenuItem>
-            </Link>
-            <Link to="/settings">
-              <MenuItem onClick={this.handleMenuClose}>
-                <ListItemIcon>
-                  <Settings />
-                </ListItemIcon>
-                <ListItemText>
-                  <Translate text="Settings" />
-                </ListItemText>
-              </MenuItem>
-            </Link>
-          </div>
-        )}
-        <Link to="/">
-          <MenuItem onClick={this.handleMenuClose}>
-            <ListItemIcon>
-              <Info />
-            </ListItemIcon>
-            <ListItemText>
-              <Translate text="About" />
-            </ListItemText>
-          </MenuItem>
-        </Link>
-        {isAdmin ? (
-          <Link to="/admin">
-            <MenuItem onClick={this.handleMenuClose}>
-              <ListItemIcon>
-                <ListIcon />
-              </ListItemIcon>
-              <ListItemText>
-                <Translate text="Admin" />
-              </ListItemText>
-            </MenuItem>
-          </Link>
-        ) : null}
         {accessToken ? (
           <Link to="/logout">
             <MenuItem onClick={this.handleMenuClose}>
@@ -331,6 +184,7 @@ class StaticAppBar extends Component {
     }
     return (
       <div>
+        <CssBaseline />
         <HideOnScroll>
           <AppBar>
             <Toolbar className="app-bar" variant="dense">
@@ -372,26 +226,24 @@ class StaticAppBar extends Component {
                 >
                   <MoreVertIcon />
                 </IconButton>
-                <Menu
-                  id="menu-popper"
-                  anchorEl={anchorEl}
-                  open={open}
-                  onClose={this.handleMenuClose}
-                  anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
-                  transformOrigin={{ horizontal: 'right', vertical: 'top' }}
-                  getContentAnchorEl={null}
-                  transitionDuration={0}
-                >
-                  <MenuItem key="placeholder" style={{ display: 'none' }} />
-                  <Logged />
-                </Menu>
+                <Popper open={open} anchorEl={anchorEl} transition>
+                  {({ TransitionProps }) => (
+                    <ClickAwayListener onClickAway={this.handleMenuClose}>
+                      <Fade {...TransitionProps}>
+                        <Paper>
+                          <Logged />
+                        </Paper>
+                      </Fade>
+                    </ClickAwayListener>
+                  )}
+                </Popper>
               </TopRightMenuContainer>
             </Toolbar>
           </AppBar>
         </HideOnScroll>
-        <Drawer open={drawerOpen} onClose={this.handleDrawerToggle}>
-          <List>{menuLinks}</List>
-        </Drawer>
+        <StyledDrawer open={drawerOpen} onClose={this.handleDrawerToggle}>
+          <LeftMenu handleDrawerClose={this.handleDrawerToggle} />
+        </StyledDrawer>
       </div>
     );
   }

--- a/src/components/StaticAppBar/TopMenu.js
+++ b/src/components/StaticAppBar/TopMenu.js
@@ -1,0 +1,174 @@
+import React from 'react';
+import MenuItem from '@material-ui/core/MenuItem';
+import ExpandMore from '@material-ui/icons/ExpandMore';
+import ExpandLess from '@material-ui/icons/ExpandLess';
+import styled, { css } from 'styled-components';
+import Link from '../shared/Link';
+import _ from 'lodash';
+import PropTypes from 'prop-types';
+import LINKS from './constants';
+import { connect } from 'react-redux';
+import { StyledIconButton } from '../shared/TopBarStyles';
+import { withRouter } from 'react-router-dom';
+import Popper from '@material-ui/core/Popper';
+import ClickAwayListener from '@material-ui/core/ClickAwayListener';
+import Fade from '@material-ui/core/Fade';
+import Paper from '@material-ui/core/Paper';
+import throttle from 'lodash.throttle';
+
+const NavLinkContainer = styled.div`
+  margin-left: 2rem;
+  display: flex;
+  align-items: center;
+  @media (max-width: 800px) {
+    display: none;
+  }
+`;
+
+const NavLink = styled(Link)`
+  color: white;
+  :hover {
+    color: white;
+  }
+`;
+
+const NavButton = styled(StyledIconButton)`
+  margin: 0 1rem;
+  text-transform: none;
+  color: white;
+  word-spacing: 2px;
+  font-size: 1rem;
+  padding: 0.75rem;
+  ${props =>
+    props.isActive === true &&
+    css`
+      border-bottom: 2px solid #ffffff;
+    `}
+`;
+
+class NavMenu extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      anchorEl: null,
+      activeTab: null,
+    };
+    this.throttledMenuClose = throttle(this.handleClose, 400);
+  }
+
+  handleClick = event => {
+    if (this.state.anchorEl !== event.currentTarget) {
+      this.setState({ anchorEl: event.currentTarget });
+    }
+  };
+
+  componentDidUpdate(prevProps) {
+    if (this.props.location !== prevProps.location) {
+      this.onRouteChanged();
+    }
+  }
+
+  handleClose = () => {
+    this.setState({ anchorEl: null });
+  };
+
+  onRouteChanged = () => {
+    const { pathname } = this.props.location;
+    const arr = pathname.split('/');
+    const label = arr.length <= 1 ? arr.pop() : arr[1];
+    if (label === '') {
+      this.setState({ activeTab: 'About' });
+      return;
+    }
+    this.setState({
+      activeTab: label.charAt(0).toUpperCase() + label.slice(1),
+    });
+    return;
+  };
+
+  componentDidMount() {
+    this.onRouteChanged();
+    window.addEventListener('scroll', this.throttledMenuClose);
+  }
+
+  componentWillUnmount() {
+    window.removeEventListener('scroll', this.throttledMenuClose);
+  }
+
+  render() {
+    const { anchorEl, activeTab } = this.state;
+
+    const open = Boolean(anchorEl);
+    const { url, label, sublinks = [] } = this.props.link;
+
+    const listItems = sublinks.map(({ label, url }) => (
+      <Link key={label} to={url}>
+        <MenuItem onClick={this.handleClose}>{label}</MenuItem>
+      </Link>
+    ));
+    const renderIcon = open ? <ExpandLess /> : <ExpandMore />;
+    return (
+      <React.Fragment key={label}>
+        {!_.isEmpty(sublinks) ? (
+          <NavButton
+            isActive={activeTab === label}
+            key={label}
+            onClick={this.handleClick}
+          >
+            {label}
+            {renderIcon}
+          </NavButton>
+        ) : (
+          <NavButton key={label}>
+            <NavLink to={url}>{label}</NavLink>
+          </NavButton>
+        )}
+        {!_.isEmpty(sublinks) && (
+          <Popper open={open} anchorEl={anchorEl} transition>
+            {({ TransitionProps }) => (
+              <ClickAwayListener onClickAway={this.handleClose}>
+                <Fade {...TransitionProps}>
+                  <Paper>{listItems}</Paper>
+                </Fade>
+              </ClickAwayListener>
+            )}
+          </Popper>
+        )}
+      </React.Fragment>
+    );
+  }
+}
+
+NavMenu.propTypes = {
+  link: PropTypes.object,
+  history: PropTypes.object,
+  location: PropTypes.object,
+};
+
+const WithRouterMenu = withRouter(NavMenu);
+
+class TopMenu extends React.Component {
+  static propTypes = {
+    isAdmin: PropTypes.bool,
+    accessToken: PropTypes.string,
+  };
+  render() {
+    const { isAdmin, accessToken } = this.props;
+    const navLinks = LINKS(accessToken, isAdmin).map(link => {
+      return <WithRouterMenu key={link.label} link={link} />;
+    });
+    return <NavLinkContainer>{navLinks}</NavLinkContainer>;
+  }
+}
+
+function mapStateToProps(store) {
+  return {
+    isAdmin: store.app.isAdmin,
+    accessToken: store.app.accessToken,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null,
+)(TopMenu);

--- a/src/components/StaticAppBar/constants.js
+++ b/src/components/StaticAppBar/constants.js
@@ -1,0 +1,56 @@
+import Info from '@material-ui/icons/Info';
+import Chat from '@material-ui/icons/Chat';
+import Dashboard from '@material-ui/icons/Dashboard';
+import ListIcon from '@material-ui/icons/List';
+
+const LINKS = (accessToken, isAdmin) => {
+  return [
+    {
+      label: 'Chat',
+      url: '/chat',
+      Icon: Chat,
+    },
+    {
+      label: 'Skills',
+      url: '/skills',
+      Icon: Dashboard,
+      sublinks: accessToken
+        ? [
+            { label: 'Browse', url: '/skills' },
+            { label: 'Botbuilder', url: '/skills/botbuilder' },
+            { label: 'Create Skill', url: '/skills/skillCreator' },
+            { label: 'Create Bot', url: '/skills/botbuilder/botwizard' },
+            { label: 'Dashboard', url: '/skills/dashboard' },
+          ]
+        : [{ label: 'Browse', url: '/skills' }],
+    },
+    {
+      label: 'About',
+      url: '/',
+      Icon: Info,
+      sublinks: [
+        { label: 'Overview', url: '/' },
+        { label: 'Devices', url: '/about/devices' },
+        { label: 'Blog', url: '/about/blog' },
+        { label: 'Team', url: '/about/team' },
+        { label: 'Support', url: '/about/support' },
+      ],
+    },
+    isAdmin
+      ? {
+          label: 'Admin',
+          url: '/admin',
+          Icon: ListIcon,
+          sublinks: [
+            { label: 'Admin', url: '/admin' },
+            { label: 'Users', url: '/admin/users' },
+            { label: 'Skills', url: '/admin/skills' },
+            { label: 'System Settings', url: '/admin/settings' },
+            { label: 'Logs', url: '/admin/logs' },
+          ],
+        }
+      : {},
+  ];
+};
+
+export default LINKS;


### PR DESCRIPTION
Fixes #2345, #2388

Changes: 
- Fix scroll on IconButton Click in AppBar
- The scroll was blocked when the menu was open on the top right, fixed that as well
- Reimplemented Top Menu and Left menu connecting the application and improving the navigation.

Demo Link: https://pr-2370-fossasia-susi-web-chat.surge.sh

Screenshots of the change:

Top Menu:

<img width="1440" alt="Screenshot 2019-06-28 at 2 35 03 PM" src="https://user-images.githubusercontent.com/18073126/60331324-08a88100-99b2-11e9-960e-568525d67182.png">

<img width="334" alt="Screenshot 2019-06-28 at 2 35 09 PM" src="https://user-images.githubusercontent.com/18073126/60331326-09411780-99b2-11e9-87f6-af98a4ac7f7b.png">

Left Menu for mobile view:

<img width="346" alt="Screenshot 2019-06-25 at 2 50 45 PM" src="https://user-images.githubusercontent.com/18073126/60086406-a7d23c00-9758-11e9-8951-404cb153d91c.png">