### PR TITLE
Fixes:#2338: Added Circular loader in place of Default loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ jest
 ..env.swp
 package-lock.json
 .vscode/
+

--- a/src/components/Settings/DevicesTab/index.js
+++ b/src/components/Settings/DevicesTab/index.js
@@ -9,6 +9,7 @@ import uiActions from '../../../redux/actions/ui';
 import { addUserDevice, removeUserDevice } from '../../../apis/index';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
+import CircularLoader from '../../shared/CircularLoader';
 
 const EmptyDevicesText = styled.div`
   font-size: 24px;
@@ -218,7 +219,14 @@ function mapDispatchToProps(dispatch) {
   };
 }
 
+const LoadingContainer = props => <CircularLoader height={27} />;
+
 export default connect(
   mapStateToProps,
   mapDispatchToProps,
-)(GoogleApiWrapper(props => ({ apiKey: props.mapKey }))(DevicesTab));
+)(
+  GoogleApiWrapper(props => ({
+    LoadingContainer: LoadingContainer,
+    apiKey: props.mapKey,
+  }))(DevicesTab),
+);


### PR DESCRIPTION
Fixes #2338 

Changes: Added a new circular loader in place of the default loader

Demo Link: https://pr-2378-fossasia-susi-web-chat.surge.sh

Screenshots of the change:
* Before change

![](https://user-images.githubusercontent.com/32234926/59898193-57cc4000-940d-11e9-915d-f0116dc73b3f.JPG)

* After change

![Screenshot from 2019-06-26 12-28-41](https://user-images.githubusercontent.com/45489945/60158132-0a394400-980e-11e9-96b8-c20df8ba0576.png)
