### PR TITLE
Fix preview chat response based on live skill #2432

### DIFF
--- a/src/components/cms/BotBuilder/Preview/Preview.js
+++ b/src/components/cms/BotBuilder/Preview/Preview.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { getSusiPreviewReply } from '../../../../apis';
+import { fetchConversationResponse } from '../../../../apis';
 import Send from '@material-ui/icons/Send';
 import loadingGIF from '../../../../images/loading.gif';
 import './Chatbot.css';
@@ -27,10 +27,12 @@ class Preview extends Component {
 
   sendMessage = event => {
     const { message } = this.state;
+    const { code } = this.props;
     if (message.trim().length > 0) {
       this.addMessage(message, 'You');
       const encodedMessage = encodeURIComponent(message);
-      getSusiPreviewReply(encodedMessage)
+      const encodedCode = encodeURIComponent(code);
+      fetchConversationResponse({ q: encodedMessage, instant: encodedCode })
         .then(payload => {
           const { messages } = this.state;
           let index;
@@ -310,6 +312,7 @@ class Preview extends Component {
 
 Preview.propTypes = {
   design: PropTypes.object,
+  code: PropTypes.string,
   botBuilder: PropTypes.bool,
   botbuilderBackgroundBody: PropTypes.string,
   botbuilderBodyBackgroundImg: PropTypes.string,
@@ -323,6 +326,7 @@ Preview.propTypes = {
 function mapStateToProps(store) {
   return {
     design: store.create.design,
+    code: store.create.skill.code,
   };
 }
 


### PR DESCRIPTION
Fixes #2432

Changes: Fix preview chat response based on live skill

Demo Link: https://pr-2443-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 

<img width="1527" alt="Screenshot 2019-07-04 at 10 10 09 PM" src="https://user-images.githubusercontent.com/18073126/60680336-81bf4100-9ea8-11e9-83f2-cd0f7ca07419.png">


