### PR TITLE
Add line break in Admin skills on enough space #2476

### DIFF
--- a/src/components/Admin/ListSkills/ListSkills.js
+++ b/src/components/Admin/ListSkills/ListSkills.js
@@ -33,6 +33,9 @@ const commonActionStyle = css`
 
 const ActionSpan = styled.span`
   ${commonActionStyle};
+  @media (max-width: 1340px) {
+    margin-right: 0.2rem;
+  }
 `;
 
 const ActionDiv = styled.div`
@@ -42,6 +45,9 @@ const ActionDiv = styled.div`
 const ActionSeparator = styled.span`
   margin-left: 0.313rem;
   margin-right: 0.313rem;
+  @media (max-width: 1340px) {
+    display: none;
+  }
 `;
 
 class ListSkills extends React.Component {


### PR DESCRIPTION
Fixes #2476

Changes: Fix line break for smaller laptop screens the action buttons disappear in the admin table. Expected: A line break happens in enough space.

Demo Link: https://pr-2479-fossasia-susi-web-chat.surge.sh

Screenshots of the change:

<img width="718" alt="Screenshot 2019-07-07 at 4 08 13 AM" src="https://user-images.githubusercontent.com/18073126/60761758-1d011380-a06d-11e9-9ee7-9a28ccd5b7fc.png">

On larger laptop:

<img width="786" alt="Screenshot 2019-07-07 at 4 08 23 AM" src="https://user-images.githubusercontent.com/18073126/60761759-1d011380-a06d-11e9-8d9c-531cc7230feb.png">

