### PR TITLE
Remove slug /skills across web-app

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -109,7 +109,7 @@ class App extends Component {
       showCookiePolicy,
       visited,
     } = this.props;
-    const skillListRegex = new RegExp('^/skills');
+    const skillListRegex = new RegExp('^/');
     const pathLength = pathname.split('/').length;
     const renderFooterPagesList = [
       '/',
@@ -117,7 +117,6 @@ class App extends Component {
       '/team',
       '/blog',
       '/devices',
-      '/skills',
       '/support',
       '/privacy',
       '/terms',
@@ -125,7 +124,7 @@ class App extends Component {
     ];
     const renderAppBar = pathname !== '/chat' ? <NavigationBar /> : null;
     const renderFooter =
-      (skillListRegex.test(pathname) && pathLength > 3 && pathLength <= 5) ||
+      (skillListRegex.test(pathname) && pathLength > 2 && pathLength <= 4) ||
       renderFooterPagesList.includes(pathname) ? (
         <Footer />
       ) : null;
@@ -134,7 +133,7 @@ class App extends Component {
       showCookiePolicy === true ? <CookiePolicy /> : null;
     const renderDialog = isModalOpen || !visited ? <DialogSection /> : null;
 
-    const applyFooterStyle = ['/skills/botbuilder/botwizard'];
+    const applyFooterStyle = ['/botbuilder/botwizard'];
 
     return (
       <StylesProvider injectFirst>
@@ -157,69 +156,61 @@ class App extends Component {
               <Route exact path="/chat" component={ChatApp} />
               <Route
                 exact
-                path="/skills/category/:category"
+                path="/category/:category"
                 component={BrowseSkillByCategory}
               />
               <Route
                 exact
-                path="/skills/language/:language"
+                path="/language/:language"
                 component={BrowseSkillByLanguage}
               />
               <Route
                 exact
-                path="/skills/:category/:skills/:lang"
+                path="/:category/:skills/:lang"
                 component={SkillListing}
               />
               <Route
                 exact
-                path="/skills/:category/:skills/:lang/feedbacks"
+                path="/:category/:skills/:lang/feedbacks"
                 component={SkillFeedbackPage}
               />
-              <ProtectedRoute
-                exact
-                path="/skills/dashboard/"
-                component={Dashboard}
-              />
+              <ProtectedRoute exact path="/dashboard/" component={Dashboard} />
               <Route
                 exact
-                path="/skills/:category/:skill/versions/:lang"
+                path="/:category/:skill/versions/:lang"
                 component={SkillVersion}
               />
               <Route
                 exact
-                path="/skills/:category/:skill/compare/:lang/:oldid/:recentid"
+                path="/:category/:skill/compare/:lang/:oldid/:recentid"
                 component={SkillHistory}
               />
               <Route
                 exact
-                path="/skills/:category/:skill/edit/:lang/:latestid/:revertid"
+                path="/:category/:skill/edit/:lang/:latestid/:revertid"
                 component={SkillRollBack}
               />
               <Route
                 exact
-                path="/skills/:category/:skill/edit/:lang"
+                path="/:category/:skill/edit/:lang"
                 component={SkillWizard}
               />
               <Route
                 exact
-                path="/skills/:category/:skill/edit/:lang/:commit"
+                path="/:category/:skill/edit/:lang/:commit"
+                component={SkillWizard}
+              />
+              <ProtectedRoute exact path="/myskills" component={Dashboard} />
+              <ProtectedRoute
+                exact
+                path="/skillWizard"
                 component={SkillWizard}
               />
               <ProtectedRoute
-                exact
-                path="/skills/myskills"
-                component={Dashboard}
-              />
-              <ProtectedRoute
-                exact
-                path="/skills/skillWizard"
-                component={SkillWizard}
-              />
-              <ProtectedRoute
-                path="/skills/botbuilder/botwizard"
+                path="/botbuilder/botwizard"
                 component={BotBuilderWrap}
               />
-              <ProtectedRoute path="/skills/botbuilder" component={Dashboard} />
+              <ProtectedRoute path="/botbuilder" component={Dashboard} />
               <Route exact path="/about" component={Overview} />
               <Route exact path="/devices" component={Devices} />
               <Route exact path="/team" component={Team} />

--- a/src/__tests__/components/SkillCreator/SkillWizard.js
+++ b/src/__tests__/components/SkillCreator/SkillWizard.js
@@ -10,9 +10,7 @@ describe('<SkillWizard />', () => {
   it('render SkillWizard without crashing', () => {
     shallow(
       <Provider store={store}>
-        <SkillWizard
-          location={{ pathname: '/skills/:category/:skill/edit/:lang' }}
-        />
+        <SkillWizard location={{ pathname: '/:category/:skill/edit/:lang' }} />
       </Provider>,
     );
   });

--- a/src/__tests__/components/SkillHistory/SkillHistory.js
+++ b/src/__tests__/components/SkillHistory/SkillHistory.js
@@ -12,7 +12,7 @@ describe('<SkillHistory />', () => {
       <Provider store={store}>
         <SkillHistory
           location={{
-            pathname: '/skills/:category/:skill/compare/:lang/:oldid/:recentid',
+            pathname: '/:category/:skill/compare/:lang/:oldid/:recentid',
           }}
         />
       </Provider>,

--- a/src/__tests__/components/SkillRollBack/SkillRollBack.js
+++ b/src/__tests__/components/SkillRollBack/SkillRollBack.js
@@ -12,7 +12,7 @@ describe('<SkillRollBack />', () => {
       <Provider store={store}>
         <SkillRollBack
           location={{
-            pathname: '/skills/:category/:skill/edit/:lang/:latestid/:revertid',
+            pathname: '/:category/:skill/edit/:lang/:latestid/:revertid',
           }}
         />
       </Provider>,

--- a/src/__tests__/components/SkillVersion/SkillVersion.js
+++ b/src/__tests__/components/SkillVersion/SkillVersion.js
@@ -11,7 +11,7 @@ describe('<SkillVersion />', () => {
     shallow(
       <Provider store={store}>
         <SkillVersion
-          location={{ pathname: '/skills/:category/:skill/versions/:lang' }}
+          location={{ pathname: '/:category/:skill/versions/:lang' }}
         />
       </Provider>,
     );

--- a/src/components/NavigationBar/TopMenu.js
+++ b/src/components/NavigationBar/TopMenu.js
@@ -52,9 +52,15 @@ class NavMenu extends React.Component {
   onRouteChanged = () => {
     const { pathname } = this.props.location;
     const arr = pathname.split('/');
-    const label = arr[1];
+    let label = null;
+    if (arr[1] === 'chat') {
+      label = 'Chat';
+    } else {
+      const skillLabel = ['dashboard', '', 'skillWizard', 'myskills'];
+      label = skillLabel.indexOf(arr[1]) > -1 ? 'Skills' : null;
+    }
     this.setState({
-      activeTab: label.charAt(0).toUpperCase() + label.slice(1),
+      activeTab: label,
     });
     return;
   };

--- a/src/components/NavigationBar/constants.js
+++ b/src/components/NavigationBar/constants.js
@@ -14,12 +14,12 @@ const LINKS = accessToken => {
       Icon: Dashboard,
       sublinks: accessToken
         ? [
-            { label: 'Dashboard', url: '/skills/dashboard' },
+            { label: 'Dashboard', url: '/dashboard' },
             { label: 'Browse Skills', url: '/' },
-            { label: 'Create Skill', url: '/skills/skillCreator' },
-            { label: 'Create Skill Bot', url: '/skills/botbuilder' },
+            { label: 'Create Skill', url: '/myskills' },
+            { label: 'Create Skill Bot', url: '/botbuilder' },
           ]
-        : [{ label: 'Browse', url: '/' }],
+        : [{ label: 'Browse Skills', url: '/' }],
     },
   ];
 };

--- a/src/components/cms/AuthorSkills/AuthorSkills.js
+++ b/src/components/cms/AuthorSkills/AuthorSkills.js
@@ -92,8 +92,8 @@ class AuthorSkills extends Component {
         name}`;
       const pngImage = `${image}.png`;
       const jpgImage = `${image}.jpg`;
-      const categoryURL = `${window.location.protocol}//${window.location.host}/skills/category/${category}/`;
-      const skillURL = `${window.location.protocol}//${window.location.host}/skills/${category}/${name}/${language}`;
+      const categoryURL = `${window.location.protocol}//${window.location.host}/category/${category}/`;
+      const skillURL = `${window.location.protocol}//${window.location.host}/${category}/${name}/${language}`;
 
       name = name.charAt(0).toUpperCase() + name.slice(1);
       if (name.split('_').length > 1) {

--- a/src/components/cms/BotBuilder/BotBuilder.js
+++ b/src/components/cms/BotBuilder/BotBuilder.js
@@ -227,7 +227,7 @@ class BotBuilder extends React.Component {
           >
             <Link
               to={
-                '/skills/botbuilder/botwizard?name=' +
+                '/botbuilder/botwizard?name=' +
                 bot.name +
                 '&language=' +
                 bot.language +
@@ -330,7 +330,7 @@ class BotBuilder extends React.Component {
               backgroundImage: 'url(' + imageUrl + ')',
             }}
           >
-            <Link to={'/skills/botbuilder/botwizard?draftID=' + draft}>
+            <Link to={'/botbuilder/botwizard?draftID=' + draft}>
               <Button variant="contained" color="primary">
                 {drafts[draft].name === '' ? draft : drafts[draft].name}
               </Button>
@@ -405,7 +405,7 @@ class BotBuilder extends React.Component {
                 return (
                   <Link
                     key={template.id}
-                    to={'/skills/botbuilder/botwizard?template=' + template.id}
+                    to={'/botbuilder/botwizard?template=' + template.id}
                   >
                     <Card
                       style={{
@@ -426,7 +426,7 @@ class BotBuilder extends React.Component {
             <br />
             <H2>Saved Bots</H2>
             <BotContainer>
-              <Link to="/skills/botbuilder/botwizard">
+              <Link to="/botbuilder/botwizard">
                 <Card
                   style={{
                     backgroundImage: 'url(/botTemplates/chat-bot.jpg)',

--- a/src/components/cms/BotBuilder/BotWizard.js
+++ b/src/components/cms/BotBuilder/BotWizard.js
@@ -688,7 +688,7 @@ class BotWizard extends React.Component {
                     </Button>
                   ) : null}
                   {stepIndex === 0 ? (
-                    <Link to="/skills/botbuilder">
+                    <Link to="/botbuilder">
                       <Button variant="contained" color="primary">
                         Cancel
                       </Button>

--- a/src/components/cms/BrowseSkill/BrowseSkill.js
+++ b/src/components/cms/BrowseSkill/BrowseSkill.js
@@ -517,7 +517,7 @@ class BrowseSkill extends React.Component {
     const { history, actions, accessToken } = this.props;
     this.handleMenuClose();
     if (accessToken) {
-      history.push('/skills/skillWizard');
+      history.push('/skillWizard');
     } else {
       actions.openModal({ modalType: 'login' });
     }
@@ -527,7 +527,7 @@ class BrowseSkill extends React.Component {
     const { history, actions, accessToken } = this.props;
     this.handleMenuClose();
     if (accessToken) {
-      history.push('/skills/botbuilder/botwizard');
+      history.push('/botbuilder/botwizard');
     } else {
       actions.openModal({ modalType: 'login' });
     }
@@ -566,7 +566,7 @@ class BrowseSkill extends React.Component {
         </MobileBackButton>
       );
       renderMobileMenu = groups.map(categoryName => {
-        const linkValue = '/skills/category/' + categoryName;
+        const linkValue = '/category/' + categoryName;
         return (
           <Link to={linkValue} key={linkValue}>
             <MobileMenuItem key={categoryName} value={categoryName}>
@@ -579,7 +579,7 @@ class BrowseSkill extends React.Component {
     }
     if (!isMobile) {
       renderMenu = groups.map(categoryName => {
-        const linkValue = '/skills/category/' + categoryName;
+        const linkValue = '/category/' + categoryName;
         return (
           <Link to={linkValue} key={linkValue}>
             <SidebarItem key={categoryName} value={categoryName}>

--- a/src/components/cms/BrowseSkill/BrowseSkillByCategory.js
+++ b/src/components/cms/BrowseSkill/BrowseSkillByCategory.js
@@ -5,13 +5,13 @@ import PropTypes from 'prop-types';
 export default class BrowseSkillByCategory extends Component {
   componentDidMount() {
     document.title = `SUSI.AI - ${
-      this.props.location.pathname.split('/')[3]
+      this.props.location.pathname.split('/')[2]
     } Skills`;
   }
   render() {
     let category = '';
     if (this.props.location) {
-      category = this.props.location.pathname.split('/')[3];
+      category = this.props.location.pathname.split('/')[2];
     }
 
     return <BrowseSkill routeType="category" routeValue={category} />;

--- a/src/components/cms/BrowseSkill/BrowseSkillByLanguage.js
+++ b/src/components/cms/BrowseSkill/BrowseSkillByLanguage.js
@@ -6,13 +6,13 @@ import ISO6391 from 'iso-639-1';
 export default class BrowseSkillByCategory extends React.Component {
   componentDidMount() {
     document.title = `SUSI.AI - ${ISO6391.getNativeName(
-      this.props.location.pathname.split('/')[3],
+      this.props.location.pathname.split('/')[2],
     )} Skills`;
   }
   render() {
     let language = '';
     if (this.props.location) {
-      language = this.props.location.pathname.split('/')[3];
+      language = this.props.location.pathname.split('/')[2];
     }
     return <BrowseSkill routeType="language" routeValue={language} />;
   }

--- a/src/components/cms/Dashboard/MyRatings.js
+++ b/src/components/cms/Dashboard/MyRatings.js
@@ -103,7 +103,7 @@ class MyRatings extends Component {
                       <StyledTableCell style={{ fontSize: '1rem' }}>
                         <Link
                           to={{
-                            pathname: `/skills/${group}/${skillName
+                            pathname: `/${group}/${skillName
                               .toLowerCase()
                               .replace(/ /g, '_')}/language`,
                           }}
@@ -131,7 +131,7 @@ class MyRatings extends Component {
           <div style={{ textAlign: 'center', paddingTop: '1rem' }}>
             <h2>
               You have not rated any skill, go to{' '}
-              <Link to="/skills">SUSI Skills Explorer</Link> and rate.
+              <Link to="/">SUSI Skills Explorer</Link> and rate.
             </h2>
           </div>
         )}

--- a/src/components/cms/Dashboard/MySkills.js
+++ b/src/components/cms/Dashboard/MySkills.js
@@ -136,7 +136,7 @@ class MySkills extends Component {
             anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
           >
             <MenuList disableListWrap={true}>
-              <Link to="/skills/skillWizard">
+              <Link to="/skillWizard">
                 <MenuItem onClose={this.handleMenuClose}>
                   <ListItemIcon>
                     <Add />
@@ -144,7 +144,7 @@ class MySkills extends Component {
                   <ListItemText>Create a Skill</ListItemText>
                 </MenuItem>
               </Link>
-              <Link to="/skills/botbuilder/botwizard">
+              <Link to="/botbuilder/botwizard">
                 <MenuItem onClose={this.handleMenuClose}>
                   <ListItemIcon>
                     <Person />
@@ -191,7 +191,7 @@ class MySkills extends Component {
                       <StyledTableCell>
                         <Link
                           to={{
-                            pathname: `/skills/${group}/${skillTag
+                            pathname: `/${group}/${skillTag
                               .toLowerCase()
                               .replace(/ /g, '_')}/${language}`,
                           }}
@@ -214,7 +214,7 @@ class MySkills extends Component {
                         {skillName ? (
                           <Link
                             to={{
-                              pathname: `/skills/${group}/${skillTag
+                              pathname: `/${group}/${skillTag
                                 .toLowerCase()
                                 .replace(/ /g, '_')}/${language}`,
                             }}

--- a/src/components/cms/Dashboard/index.js
+++ b/src/components/cms/Dashboard/index.js
@@ -36,11 +36,11 @@ class Dashboard extends Component {
 
   getCurrentTab = () => {
     switch (this.props.location.pathname) {
-      case '/skills/dashboard':
+      case '/dashboard':
         return 0;
-      case '/skills/myskills':
+      case '/myskills':
         return 1;
-      case '/skills/botbuilder':
+      case '/botbuilder':
         return 2;
       default:
         return 0;
@@ -52,13 +52,13 @@ class Dashboard extends Component {
     const { history } = this.props;
     switch (value) {
       case 0:
-        history.replace('/skills/dashboard');
+        history.replace('/dashboard');
         break;
       case 1:
-        history.replace('/skills/myskills');
+        history.replace('/myskills');
         break;
       case 2:
-        history.replace('/skills/botbuilder');
+        history.replace('/botbuilder');
         break;
       default:
         history.replace('/dashboard');

--- a/src/components/cms/SkillCardGrid/SkillCardGrid.js
+++ b/src/components/cms/SkillCardGrid/SkillCardGrid.js
@@ -40,7 +40,7 @@ class SkillCardGrid extends Component {
     Object.keys(this.props.skills).forEach(el => {
       let skill = this.props.skills[el];
       const dataId = `index-${el}`;
-      const skillPathname = `/skills/${skill.group}/${skill.skillTag}/${skill.language}`;
+      const skillPathname = `/${skill.group}/${skill.skillTag}/${skill.language}`;
       const skillFeedbackPathname = `${skillPathname}/feedbacks`;
       let skillName,
         examples,

--- a/src/components/cms/SkillCardList/SkillCardList.js
+++ b/src/components/cms/SkillCardList/SkillCardList.js
@@ -147,7 +147,7 @@ function createListCard(
   { history },
 ) {
   const dataId = `index-${el}`;
-  const skillPathname = `/skills/${skill.group}/${skill.skillTag}/${skill.language}`;
+  const skillPathname = `/${skill.group}/${skill.skillTag}/${skill.language}`;
   const skillFeedbackPathname = `${skillPathname}/feedbacks`;
   const mobileView = window.innerWidth < 430;
   if (mobileView) {
@@ -265,7 +265,7 @@ function createListCard(
                   <Link
                     key={el}
                     to={{
-                      pathname: `/skills/${skill.group}/${skill.skillTag}/${skill.language}/feedbacks`,
+                      pathname: `/${skill.group}/${skill.skillTag}/${skill.language}/feedbacks`,
                     }}
                   >
                     <Ratings

--- a/src/components/cms/SkillCardScrollList/SkillCard.js
+++ b/src/components/cms/SkillCardScrollList/SkillCard.js
@@ -166,7 +166,7 @@ class SkillCard extends Component {
               key={el}
               to={{
                 pathname:
-                  '/skills/' +
+                  '/' +
                   skill.group +
                   '/' +
                   skill.skillTag +
@@ -187,7 +187,7 @@ class SkillCard extends Component {
               <Link
                 to={{
                   pathname:
-                    '/skills/' +
+                    '/' +
                     skill.group +
                     '/' +
                     skill.skillTag +
@@ -204,7 +204,7 @@ class SkillCard extends Component {
                 key={el}
                 to={{
                   pathname:
-                    '/skills/' +
+                    '/' +
                     skill.group +
                     '/' +
                     skill.skillTag +

--- a/src/components/cms/SkillCreator/SkillCreator.js
+++ b/src/components/cms/SkillCreator/SkillCreator.js
@@ -154,7 +154,7 @@ class SkillCreator extends Component {
           >
             <Link
               to={{
-                pathname: `/skills/${group}/${skillTag
+                pathname: `/${group}/${skillTag
                   .toLowerCase()
                   .replace(/ /g, '_')}/${language}`,
               }}
@@ -166,7 +166,7 @@ class SkillCreator extends Component {
             <SkillActions>
               <Link
                 to={{
-                  pathname: `/skills/${group}/${skillTag
+                  pathname: `/${group}/${skillTag
                     .toLowerCase()
                     .replace(/ /g, '_')}/edit/${language}`,
                 }}
@@ -194,7 +194,7 @@ class SkillCreator extends Component {
             <CircularLoader height={5} />
           ) : (
             <SkillCardWrap>
-              <Link to="/skills/skillWizard">
+              <Link to="/skillWizard">
                 <SkillCard
                   style={{
                     backgroundImage: 'url(/botTemplates/chat-bot.jpg)',

--- a/src/components/cms/SkillCreator/SkillWizard.js
+++ b/src/components/cms/SkillCreator/SkillWizard.js
@@ -382,7 +382,7 @@ class SkillWizard extends Component {
   constructor(props) {
     super(props);
 
-    this.isBotBuilder = window.location.pathname.split('/')[2] === 'botbuilder';
+    this.isBotBuilder = window.location.pathname.split('/')[1] === 'botbuilder';
 
     let commonState = {
       groups: [],
@@ -402,14 +402,14 @@ class SkillWizard extends Component {
 
     if (
       this.props.location &&
-      this.props.location.pathname.split('/')[4] === 'edit'
+      this.props.location.pathname.split('/')[3] === 'edit'
     ) {
       const { pathname } = this.props.location;
       this.mode = 'edit';
-      this.groupValue = pathname.split('/')[2];
-      this.languageValue = pathname.split('/')[5];
+      this.groupValue = pathname.split('/')[1];
+      this.languageValue = pathname.split('/')[4];
       this.expertValue = pathname.split('/')[3];
-      this.commitId = pathname.split('/')[6];
+      this.commitId = pathname.split('/')[5];
 
       let commitMessage = `Updated Skill ${this.expertValue}`;
       if (this.props.hasOwnProperty('revertingCommit')) {
@@ -882,7 +882,7 @@ class SkillWizard extends Component {
             if (!this.props.hasOwnProperty('revertingCommit')) {
               this.props.history.push({
                 pathname:
-                  '/skills/' +
+                  '/' +
                   category +
                   '/' +
                   name.trim().replace(/\s/g, '_') +
@@ -947,7 +947,7 @@ class SkillWizard extends Component {
             if (!this.props.hasOwnProperty('revertingCommit')) {
               this.props.history.push({
                 pathname:
-                  '/skills/' +
+                  '/' +
                   category +
                   '/' +
                   name.trim().replace(/\s/g, '_') +
@@ -1291,15 +1291,10 @@ class SkillWizard extends Component {
                       <Link
                         to={
                           this.mode === 'create'
-                            ? '/skills'
+                            ? '/'
                             : {
                                 pathname:
-                                  '/skills/' +
-                                  category +
-                                  '/' +
-                                  name +
-                                  '/' +
-                                  language,
+                                  '/' + category + '/' + name + '/' + language,
                               }
                         }
                       >

--- a/src/components/cms/SkillFeedbackPage/SkillFeedbackPage.js
+++ b/src/components/cms/SkillFeedbackPage/SkillFeedbackPage.js
@@ -566,7 +566,7 @@ class SkillFeedbackPage extends Component {
           <Paper margin={2}>
             <p style={{ marginLeft: 10 }}>
               <Link
-                to={`/skills/${this.groupValue}/${this.skillTag}/${this.languageValue}`}
+                to={`/${this.groupValue}/${this.skillTag}/${this.languageValue}`}
                 style={{ color: '#000000' }}
               >
                 {this.skillName}
@@ -577,7 +577,7 @@ class SkillFeedbackPage extends Component {
             <SkillDetailContainer>
               <div style={{ paddingLeft: '2%' }}>
                 <Link
-                  to={`/skills/${this.groupValue}/${this.skillTag}/${this.languageValue}`}
+                  to={`/${this.groupValue}/${this.skillTag}/${this.languageValue}`}
                 >
                   {image == null ? (
                     <CircleImage
@@ -592,7 +592,7 @@ class SkillFeedbackPage extends Component {
               <div style={{ paddingLeft: '2%' }}>
                 <SkillName>
                   <Link
-                    to={`/skills/${this.groupValue}/${this.skillTag}/${this.languageValue}`}
+                    to={`/${this.groupValue}/${this.skillTag}/${this.languageValue}`}
                   >
                     {skillName}
                   </Link>
@@ -676,7 +676,7 @@ class SkillFeedbackPage extends Component {
               ))}
             <Footer>
               <Link
-                to={`/skills/${this.groupValue}/${this.skillTag}/${this.languageValue}`}
+                to={`/${this.groupValue}/${this.skillTag}/${this.languageValue}`}
                 style={{ color: '#417DDE' }}
               >
                 <b>

--- a/src/components/cms/SkillHistory/SkillHistory.js
+++ b/src/components/cms/SkillHistory/SkillHistory.js
@@ -82,9 +82,9 @@ class SkillHistory extends Component {
     super(props);
     let commits = [];
     const parsePath = this.props.location.pathname.split('/');
-    commits.push(parsePath[5]);
-    if (parsePath.length === 7) {
-      commits.push(parsePath[6]);
+    commits.push(parsePath[4]);
+    if (parsePath.length === 6) {
+      commits.push(parsePath[5]);
     }
     this.state = {
       code:

--- a/src/components/cms/SkillPage/SkillListing.js
+++ b/src/components/cms/SkillPage/SkillListing.js
@@ -183,9 +183,9 @@ class SkillListing extends Component {
       seeMoreSkillExamples: true,
     };
 
-    this.groupValue = this.props.location.pathname.split('/')[2];
-    this.skillTag = this.props.location.pathname.split('/')[3];
-    this.languageValue = this.props.location.pathname.split('/')[4];
+    this.groupValue = this.props.location.pathname.split('/')[1];
+    this.skillTag = this.props.location.pathname.split('/')[2];
+    this.languageValue = this.props.location.pathname.split('/')[3];
     this.skillData = {
       model: 'general',
       group: this.groupValue,
@@ -320,8 +320,8 @@ class SkillListing extends Component {
     const skillName = _skillName === null ? 'No Name Given' : _skillName;
 
     let { seeMoreSkillExamples } = this.state;
-    const editLink = `/skills/${this.groupValue}/${this.skillTag}/edit/${this.languageValue}`;
-    const versionsLink = `/skills/${this.groupValue}/${this.skillTag}/versions/${this.languageValue}`;
+    const editLink = `/${this.groupValue}/${this.skillTag}/edit/${this.languageValue}`;
+    const versionsLink = `/${this.groupValue}/${this.skillTag}/versions/${this.languageValue}`;
 
     let renderElement = null;
     if (examples.length > 4) {
@@ -476,7 +476,7 @@ class SkillListing extends Component {
                 <tr>
                   <td>Category: </td>
                   <td>
-                    <Link to={`/skills/category/${this.groupValue}`}>
+                    <Link to={`/category/${this.groupValue}`}>
                       {this.groupValue}
                     </Link>
                   </td>
@@ -484,7 +484,7 @@ class SkillListing extends Component {
                 <tr>
                   <td>Language: </td>
                   <td>
-                    <Link to={`/skills/language/${this.languageValue}`}>
+                    <Link to={`/language/${this.languageValue}`}>
                       {ISO6391.getNativeName(this.languageValue)}
                     </Link>
                   </td>
@@ -503,7 +503,7 @@ class SkillListing extends Component {
                         <Link
                           key={index}
                           onClick={this.forceUpdate}
-                          to={`/skills/${this.groupValue}/${data.name}/${data.language}`}
+                          to={`/${this.groupValue}/${data.name}/${data.language}`}
                         >
                           {ISO6391.getNativeName(data.language)}
                           {delimiter}

--- a/src/components/cms/SkillRollBack/SkillRollBack.js
+++ b/src/components/cms/SkillRollBack/SkillRollBack.js
@@ -216,7 +216,7 @@ class SkillRollBack extends Component {
           });
 
           this.props.history.push({
-            pathname: `/skills/${skillMetaData.groupValue}/${skillMetaData.skillName}/${skillMetaData.languageValue}`,
+            pathname: `/${skillMetaData.groupValue}/${skillMetaData.skillName}/${skillMetaData.languageValue}`,
             state: {
               fromUpload: true,
               expertValue: skillMetaData.skillName,

--- a/src/components/cms/SkillVersion/SkillVersion.js
+++ b/src/components/cms/SkillVersion/SkillVersion.js
@@ -53,9 +53,9 @@ class SkillVersion extends Component {
       dataReceived: false,
       skillMeta: {
         modelValue: 'general',
-        groupValue: this.props.location.pathname.split('/')[2],
-        languageValue: this.props.location.pathname.split('/')[5],
-        skillName: this.props.location.pathname.split('/')[3],
+        groupValue: this.props.location.pathname.split('/')[1],
+        languageValue: this.props.location.pathname.split('/')[4],
+        skillName: this.props.location.pathname.split('/')[2],
       },
       checks: [],
     };
@@ -151,7 +151,7 @@ class SkillVersion extends Component {
           <TableCell padding="dense">
             <Link
               to={{
-                pathname: `/skills/${skillMeta.groupValue}/${skillMeta.skillName}/edit/${skillMeta.languageValue}/${commitId}`,
+                pathname: `/${skillMeta.groupValue}/${skillMeta.skillName}/edit/${skillMeta.languageValue}/${commitId}`,
               }}
             >
               {commitDate}
@@ -203,7 +203,7 @@ class SkillVersion extends Component {
               {checks.length === 2 && (
                 <Link
                   to={{
-                    pathname: `/skills/${skillMeta.groupValue}/${skillMeta.skillName}/compare/${skillMeta.languageValue}/${checkedCommits[0].commitId}/${checkedCommits[1].commitId}`,
+                    pathname: `/${skillMeta.groupValue}/${skillMeta.skillName}/compare/${skillMeta.languageValue}/${checkedCommits[0].commitId}/${checkedCommits[1].commitId}`,
                   }}
                 >
                   <Button position={8} variant="contained" color="primary">
@@ -213,7 +213,7 @@ class SkillVersion extends Component {
               )}
               <Link
                 to={{
-                  pathname: `/skills/${skillMeta.groupValue}/${skillMeta.skillName}/${skillMeta.languageValue}`,
+                  pathname: `/${skillMeta.groupValue}/${skillMeta.skillName}/${skillMeta.languageValue}`,
                 }}
               >
                 <Button position={2} variant="contained" color="primary">


### PR DESCRIPTION
Fixes #2489

Changes: Remove slug `/skills` across web-app. The skills slug is no longer needed to distinguish parts of the system

Demo Link: https://pr-2490-fossasia-susi-web-chat.surge.sh

