### PR TITLE
Add list of System Skills on start page

### DIFF
--- a/src/components/cms/SkillCardScrollList/SkillCardScrollList.js
+++ b/src/components/cms/SkillCardScrollList/SkillCardScrollList.js
@@ -21,6 +21,10 @@ const Container = styled.div`
 
 const skillCardListData = [
   {
+    skills: 'systemSkills',
+    heading: 'System Skills',
+  },
+  {
     skills: 'staffPicksSkills',
     heading: 'Staff Picks',
   },

--- a/src/redux/reducers/skills.js
+++ b/src/redux/reducers/skills.js
@@ -18,6 +18,7 @@ const defaultState = {
     newestSkills: [],
     topFeedbackSkills: [],
     topGames: [],
+    systemSkills: [],
   },
   // Skills
   skills: [],
@@ -69,6 +70,7 @@ export default handleActions(
         newestSkills: metrics.newest,
         topFeedbackSkills: metrics.feedback,
         topGames: metrics.gamesTriviaAndAccessories,
+        systemSkills: metrics.systemSkills,
       };
       return {
         ...state,


### PR DESCRIPTION
Fixes #2514 

Changes: Display system skills above staff picks.
Demo Link: https://pr-2526-fossasia-susi-web-chat.surge.sh
Screenshots of the change: [Add screenshots depicting the changes.]
![Screenshot 2019-07-12 at 5 23 52 PM](https://user-images.githubusercontent.com/31013104/61126379-eb070b80-a4c9-11e9-9f9d-2d1623a614dc.png)
