### PR TITLE
Fixes #2597: Remove FAB from skill slider in mobile view

### DIFF
--- a/src/components/cms/BrowseSkill/BrowseSkill.js
+++ b/src/components/cms/BrowseSkill/BrowseSkill.js
@@ -606,7 +606,7 @@ class BrowseSkill extends React.Component {
 
     let renderCardScrollList = '';
     renderCardScrollList = !metricsHidden && !routeType && (
-      <SkillCardScrollList history={history} />
+      <SkillCardScrollList isMobile={isMobile} history={history} />
     );
     let renderSkillSlideshow = null;
     renderSkillSlideshow = !metricsHidden && !routeType && <SkillSlideshow />;
@@ -798,8 +798,9 @@ class BrowseSkill extends React.Component {
         </Sidebar>
         <RightContainer>
           {renderSkillSlideshow}
-          {loadingSkills && <CircularLoader height={34} />}
-          {!loadingSkills ? (
+          {loadingSkills ? (
+            <CircularLoader height={34} />
+          ) : (
             <ContentContainer>
               {metricsHidden ? (
                 <div>
@@ -956,7 +957,7 @@ class BrowseSkill extends React.Component {
                 <MobileMenuContainer>{renderMobileMenu}</MobileMenuContainer>
               )}
             </ContentContainer>
-          ) : null}
+          )}
         </RightContainer>
       </Container>
     );

--- a/src/components/cms/SkillCardScrollList/SkillCard.js
+++ b/src/components/cms/SkillCardScrollList/SkillCard.js
@@ -250,7 +250,7 @@ class SkillCard extends Component {
 
   render() {
     const { leftBtnDisplay, rightBtnDisplay, cards } = this.state;
-    const { scrollSkills } = this.props;
+    const { scrollSkills, isMobile = false } = this.props;
     return (
       <div
         style={{
@@ -262,23 +262,27 @@ class SkillCard extends Component {
         }}
       >
         <ScrollWrapper id={scrollSkills}>
-          <LeftFab
-            size="small"
-            color="primary"
-            onClick={this.scrollLeft}
-            display={leftBtnDisplay}
-          >
-            <NavigationChevronLeft style={{ margin: '8.4px auto' }} />
-          </LeftFab>
+          {!isMobile && (
+            <LeftFab
+              size="small"
+              color="primary"
+              onClick={this.scrollLeft}
+              display={leftBtnDisplay}
+            >
+              <NavigationChevronLeft style={{ margin: '8.4px auto' }} />
+            </LeftFab>
+          )}
           {cards}
-          <RightFab
-            size="small"
-            color="primary"
-            display={rightBtnDisplay}
-            onClick={this.scrollRight}
-          >
-            <NavigationChevronRight style={{ margin: '8.4px auto' }} />
-          </RightFab>
+          {!isMobile && (
+            <RightFab
+              size="small"
+              color="primary"
+              display={rightBtnDisplay}
+              onClick={this.scrollRight}
+            >
+              <NavigationChevronRight style={{ margin: '8.4px auto' }} />
+            </RightFab>
+          )}
         </ScrollWrapper>
       </div>
     );
@@ -289,6 +293,7 @@ SkillCard.propTypes = {
   metricSkills: PropTypes.object,
   scrollSkills: PropTypes.string.isRequired,
   history: PropTypes.object,
+  isMobile: PropTypes.bool,
 };
 
 function mapStateToProps(store) {

--- a/src/components/cms/SkillCardScrollList/SkillCardScrollList.js
+++ b/src/components/cms/SkillCardScrollList/SkillCardScrollList.js
@@ -54,14 +54,18 @@ const skillCardListData = [
   },
 ];
 
-const SkillCardScrollList = ({ metricSkills, history }) => {
+const SkillCardScrollList = ({ metricSkills, history, isMobile }) => {
   let renderCardScrollList = '';
 
   renderCardScrollList = skillCardListData.map((data, index) => {
     return metricSkills[data.skills].length ? (
       <Container key={index}>
         <HeaderText>{data.heading}</HeaderText>
-        <SkillCard scrollSkills={data.skills} history={history} />
+        <SkillCard
+          isMobile={isMobile}
+          scrollSkills={data.skills}
+          history={history}
+        />
       </Container>
     ) : null;
   });
@@ -71,6 +75,7 @@ const SkillCardScrollList = ({ metricSkills, history }) => {
 SkillCardScrollList.propTypes = {
   metricSkills: PropTypes.object,
   history: PropTypes.object,
+  isMobile: PropTypes.bool,
 };
 
 function mapStateToProps(store) {


### PR DESCRIPTION
Fixes #2597 

Changes:
- Remove FAB from skill slider in mobile view

Demo Link: https://pr-2598-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
<img width="415" alt="Screenshot 2019-07-16 at 8 34 17 PM" src="https://user-images.githubusercontent.com/12656846/61305911-49552680-a809-11e9-90e6-38efadaf42ba.png">

