### PR TITLE
Fix Menu Bar icons on the right disappear on small screens

### DIFF
--- a/src/components/NavigationBar/SearchBar.js
+++ b/src/components/NavigationBar/SearchBar.js
@@ -25,7 +25,7 @@ const StyledSearchBar = styled(_SearchBar)`
   align-items: center;
   height: 35px;
   padding-left: ${props => `${props.paddingLeft}rem`};
-  width: 40rem;
+  width: 39rem;
   @media (max-width: 1280px) {
     width: 30rem;
   }

--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -64,6 +64,10 @@ const UserDetail = styled.div`
   font-size: 1rem;
   cursor: pointer;
   bottom: 8px;
+  width: 165px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   @media (max-width: 1000px) {
     display: None;
   }


### PR DESCRIPTION
Fixes #2656 

Changes: if username or email is greater than 21 character then first 21 characters + ".." will be displayed.
Changed the search bar width to 39rem.

Demo Link: https://pr-2659-fossasia-susi-web-chat.surge.sh

Screenshots of the change: [Add screenshots depicting the changes.]
![Screenshot 2019-07-23 at 5 40 47 PM](https://user-images.githubusercontent.com/31013104/61711173-0ba84e80-ad71-11e9-9bb1-ac8c268a64b2.png)

