### PR TITLE
Fix username width in navigation bar and redirect on device delete

### DIFF
--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -64,7 +64,8 @@ const UserDetail = styled.div`
   font-size: 1rem;
   cursor: pointer;
   bottom: 8px;
-  width: 165px;
+  width: auto;
+  max-width: 165px;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/components/cms/MyDevices/DeviceWizard.js
+++ b/src/components/cms/MyDevices/DeviceWizard.js
@@ -134,7 +134,7 @@ class DeviceWizard extends React.Component {
     removeUserDevice({ macId })
       .then(payload => {
         this.props.actions.closeModal();
-        window.location.replace('/settings');
+        window.location.replace('/mydevices');
       })
       .catch(error => {
         console.log(error);


### PR DESCRIPTION
Fixes #2667 

Changes: 
Fixed username width in navigation bar.
Deleting the device on device wizard redirects to `mydevices` page.

Demo Link: https://pr-2668-fossasia-susi-web-chat.surge.sh

Screenshots of the change: [Add screenshots depicting the changes.]
![Screenshot 2019-07-25 at 6 33 05 AM](https://user-images.githubusercontent.com/31013104/61838263-19abbb80-aea6-11e9-913f-163a5ffadbe4.png)

