### PR TITLE
Fix Admin: Not able to delete account and top menu link ? to /about

### DIFF
--- a/src/apis/index.js
+++ b/src/apis/index.js
@@ -662,7 +662,7 @@ export function changeUserRole(payload) {
 
 export function deleteUserAccount(payload) {
   const { email } = payload;
-  const url = `${API_URL}/${AUTH_API_PREFIX}/deleteUserAccount`;
+  const url = `${API_URL}/${AUTH_API_PREFIX}/deleteUserAccount.json`;
   return ajax.get(url, { email });
 }
 

--- a/src/components/Admin/ListUser/index.js
+++ b/src/components/Admin/ListUser/index.js
@@ -51,6 +51,8 @@ class ListUser extends Component {
           title: 'Success',
           handleConfirm: this.props.actions.closeModal,
         });
+        this.setState({ search: '' });
+        this.loadUsers();
       })
       .catch(error => {
         console.log(error);

--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -628,9 +628,11 @@ class NavigationBar extends Component {
                       </Link>
                     </Paper>
                   </Popper>
-                  <IconButton aria-haspopup="true" color="inherit">
-                    <ContactSupportIcon />
-                  </IconButton>
+                  <Link to="/about">
+                    <IconButton aria-haspopup="true" style={{ color: 'white' }}>
+                      <ContactSupportIcon />
+                    </IconButton>
+                  </Link>
                 </div>
               </TopRightMenuContainer>
             </Toolbar>


### PR DESCRIPTION
Fixes #2734 #2726 

Changes: Fixed delete user account by admin and click on `?` icon on the navigation bar redirects to `/about` route.
Demo Link: https://pr-2735-fossasia-susi-web-chat.surge.sh

Screenshots of the change: [Add screenshots depicting the changes.]
![Screenshot 2019-07-30 at 3 59 05 PM](https://user-images.githubusercontent.com/31013104/62122301-ff793f80-b2e2-11e9-9307-67c541801a76.png)

