### PR TITLE
Add Device protected route to disable skill edit in local mode #2744

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,7 @@ import Privacy from './components/Privacy/Privacy.react';
 import appActions from './redux/actions/app';
 import uiActions from './redux/actions/ui';
 import ProtectedRoute from './components/shared/ProtectedRoute';
+import DeviceProtectedRoute from './components/shared/DeviceProtectedRoute';
 import DialogSection from '../src/components/shared/Dialog';
 import settingActions from './redux/actions/settings';
 import BrowseSkill from './components/cms/BrowseSkill/BrowseSkill';
@@ -239,12 +240,12 @@ class App extends Component {
                   path="/:category/:skill/edit/:lang/:latestid/:revertid"
                   component={EnhancedSkillRollBack}
                 />
-                <Route
+                <DeviceProtectedRoute
                   exact
                   path="/:category/:skill/edit/:lang"
                   component={EnhancedSkillWizard}
                 />
-                <Route
+                <DeviceProtectedRoute
                   exact
                   path="/:category/:skill/edit/:lang/:commit"
                   component={EnhancedSkillWizard}

--- a/src/components/cms/SkillCreator/SkillWizard.js
+++ b/src/components/cms/SkillCreator/SkillWizard.js
@@ -51,14 +51,6 @@ import Timeline from '@material-ui/icons/Timeline';
 import Add from '@material-ui/icons/Add';
 import ChevronLeft from '@material-ui/icons/ChevronLeft';
 
-const Paper = styled(_Paper)`
-  width: 100%;
-  @media (max-width: 514px) {
-    padding: 0px;
-    margin-bottom: 2rem;
-  }
-`;
-
 const IconButton = styled(_IconButton)`
   @media (max-width: 451px) {
     padding-left: 3px;
@@ -251,11 +243,8 @@ const Form = styled.form`
   display: inline-block;
 `;
 
-const DeleteSkillSection = styled(Paper)`
-  width: 100%;
+const DeleteSkillSection = styled(PaperContainer)`
   border: 0.063rem solid red;
-  margin-top: 20px;
-  padding: 1.25rem;
   display: flex;
   justify-content: space-between;
   align-items: center;

--- a/src/components/shared/DeviceProtectedRoute.js
+++ b/src/components/shared/DeviceProtectedRoute.js
@@ -1,0 +1,102 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import { Route } from 'react-router-dom';
+import LogoImg from '../../images/susi-logo.svg';
+import styled from 'styled-components';
+import _Button from '@material-ui/core/Button';
+import urls from '../../utils/urls';
+
+const Button = styled(_Button)`
+  width: 332px;
+  margin-top: 2rem;
+  @media (max-width: 356px) {
+    width: 100%;
+  }
+`;
+
+const SusiLogo = styled.img.attrs({
+  alt: 'Page Not Found',
+  src: LogoImg,
+})`
+  width: 15rem;
+  margin-bottom: 2rem;
+`;
+
+const Container = styled.div`
+  min-height: 74vh;
+  width: 100%;
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  h2 {
+    font-size: 24px;
+    line-height: 1.45;
+  }
+`;
+
+const RenderAccessFromSUSI = ({ pathname }) => {
+  return (
+    <Container>
+      <a href={urls.HOME_URL}>
+        <SusiLogo />
+      </a>
+      <h2>
+        Access to this page is restricted from local device
+        <br />
+        Try accessing from public SUSI.AI site
+      </h2>
+      <a href={`${urls.HOME_URL}${pathname}`}>
+        <Button variant="contained" color="primary">
+          Access from SUSI.AI
+        </Button>
+      </a>
+    </Container>
+  );
+};
+
+RenderAccessFromSUSI.propTypes = {
+  pathname: PropTypes.string,
+};
+
+const DeviceProtectedRoute = props => {
+  const { isLocalEnv, component: Component, location, ...restProps } = props;
+  return (
+    <Route
+      {...restProps}
+      render={routeProps =>
+        !isLocalEnv ? (
+          <Component {...routeProps} />
+        ) : (
+          <RenderAccessFromSUSI pathname={location.pathname} />
+        )
+      }
+    />
+  );
+};
+
+DeviceProtectedRoute.propTypes = {
+  history: PropTypes.object,
+  component: PropTypes.oneOfType([
+    PropTypes.object,
+    PropTypes.func,
+    PropTypes.string,
+  ]),
+  isLocalEnv: PropTypes.bool,
+  location: PropTypes.object,
+};
+
+function mapStateToProps(store) {
+  const { isLocalEnv } = store.app;
+  return {
+    isLocalEnv,
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null,
+)(DeviceProtectedRoute);

--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -3,6 +3,7 @@ const urls = {
   SOUND_SERVER_API_URL: 'http://0.0.0.0:7070',
   CHAT_URL: 'https://susi.ai/chat',
   SKILL_URL: 'https://susi.ai/skills',
+  HOME_URL: 'https://susi.ai',
   GITHUB_URL: 'https://github.com/fossasia/susi.ai',
   GITHUB_AVATAR_URL: 'https://avatars.githubusercontent.com',
   GRAVATAR_URL: 'https://www.gravatar.com/avatar',


### PR DESCRIPTION
Fixes #2744, #2767

Changes:

 - [x] Added Device protected routes, ie. when on the local device, edit of skill will give message shown in the screenshot. Same for when the user tries to edit using compare id in skill version

- [x] Fix Delete Skill Alignment in SkillCreator

Demo Link: https://pr-2776-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 

<img width="1679" alt="Screenshot 2019-08-03 at 1 14 45 AM" src="https://user-images.githubusercontent.com/18073126/62394862-1e4e2f00-b58c-11e9-8171-a2b96e74f032.png">

<img width="1062" alt="Screenshot 2019-08-03 at 1 17 06 AM" src="https://user-images.githubusercontent.com/18073126/62394962-7c7b1200-b58c-11e9-8fc1-4a9e705420ff.png">

