### PR TITLE
Add email messages #2547

### DIFF
--- a/src/components/Admin/Admin.js
+++ b/src/components/Admin/Admin.js
@@ -7,9 +7,10 @@ import AppBar from '@material-ui/core/AppBar';
 import AdminTab from './AdminTab/AdminTab';
 import ListUser from './ListUser';
 import ListSkills from './ListSkills/ListSkills';
-import ListDevices from './ListDevices/index';
-import ListBots from './ListBots/index';
+import ListDevices from './ListDevices';
+import ListBots from './ListBots';
 import SystemLogs from './SystemLogs/SystemLogs';
+import Messages from './Messages';
 import Settings from './Settings';
 import { getAdmin } from '../../apis/index';
 import styled from 'styled-components';
@@ -89,8 +90,11 @@ class Admin extends Component {
       case 'settings':
         value = 5;
         break;
-      case 'logs':
+      case 'messages':
         value = 6;
+        break;
+      case 'logs':
+        value = 7;
         break;
       default:
         return;
@@ -121,6 +125,9 @@ class Admin extends Component {
         history.replace('/admin/settings');
         break;
       case 6:
+        history.replace('/admin/messages');
+        break;
+      case 7:
         history.replace('/admin/logs');
         break;
       default:
@@ -144,6 +151,8 @@ class Admin extends Component {
       case 5:
         return <Settings />;
       case 6:
+        return <Messages />;
+      case 7:
         return <SystemLogs />;
       default:
         return;
@@ -176,6 +185,7 @@ class Admin extends Component {
                     <Tab label="Bots" />
                     <Tab label="Devices" />
                     <Tab label="Settings" />
+                    <Tab label="Messages" />
                     <Tab label="System Logs" />
                   </Tabs>
                   {this.generateView()}

--- a/src/components/Admin/Messages/index.js
+++ b/src/components/Admin/Messages/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import MaterialTable from 'material-table';
+import TABLE_CONFIG from './table-config';
+import MESSAGE_CONFIG from './message-config';
+
+const Messages = () => {
+  return (
+    <MaterialTable
+      options={{
+        actionsColumnIndex: -1,
+        pageSize: 10,
+      }}
+      columns={TABLE_CONFIG}
+      data={MESSAGE_CONFIG}
+      title=""
+      style={{
+        padding: '1rem',
+        margin: '2rem',
+      }}
+    />
+  );
+};
+
+export default Messages;

--- a/src/components/Admin/Messages/message-config.js
+++ b/src/components/Admin/Messages/message-config.js
@@ -1,0 +1,46 @@
+const MESSAGE_CONFIG = [
+  {
+    recipients: 'User',
+    trigger: 'Password change',
+    emailMessage: 'Your password has been changed successfully!',
+    options: 'Mail',
+    time: 'No dates available',
+  },
+  {
+    recipients: 'User',
+    trigger: 'Password Recovery',
+    emailMessage: 'Recovery email sent to your email ID. Please check',
+    options: 'Mail',
+    time: 'No dates available',
+  },
+  {
+    recipients: 'User',
+    trigger: 'Password Reset',
+    emailMessage: 'Your password has been reset successfully!',
+    options: 'Mail',
+    time: 'No dates available',
+  },
+  {
+    recipients: 'User',
+    trigger: 'Resend Account Verification Link',
+    emailMessage: 'SUSI AI verification',
+    options: 'Mail',
+    time: 'No dates available',
+  },
+  {
+    recipients: 'User',
+    trigger: 'Sign Up',
+    emailMessage: 'SUSI AI verification',
+    options: 'Mail',
+    time: 'No dates available',
+  },
+  {
+    recipients: 'Skill Author',
+    trigger: 'Modify Skill',
+    emailMessage: 'SUSI Skill Data Conflicts',
+    options: 'Mail',
+    time: 'No dates available',
+  },
+];
+
+export default MESSAGE_CONFIG;

--- a/src/components/Admin/Messages/table-config.js
+++ b/src/components/Admin/Messages/table-config.js
@@ -1,0 +1,36 @@
+const TABLE_CONFIG = [
+  {
+    title: 'Recipients',
+    field: 'recipients',
+    cellStyle: {
+      width: '8%',
+    },
+  },
+  {
+    title: 'Trigger',
+    field: 'trigger',
+    cellStyle: {
+      width: '8%',
+    },
+  },
+  {
+    title: 'Email Message',
+    field: 'emailMessage',
+    cellStyle: {
+      width: '30%',
+    },
+  },
+  {
+    title: 'Options',
+    field: 'options',
+    cellStyle: {
+      width: '8%',
+    },
+  },
+  {
+    title: 'Time/Date sent out',
+    field: 'time',
+  },
+];
+
+export default TABLE_CONFIG;


### PR DESCRIPTION
Fixes #2547 

Changes: Add email messages sent from admin under messages tab in admin panel

Demo Link: https://pr-2777-fossasia-susi-web-chat.surge.sh

Screenshots of the change:
<img width="1678" alt="Screenshot 2019-08-03 at 11 53 52 PM" src="https://user-images.githubusercontent.com/18073126/62415592-f7563280-b649-11e9-910d-1d4900f82e75.png">


