### PR TITLE
use correct host address for SUSI Sever API URL[WIP]

### DIFF
--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -1,5 +1,12 @@
+function check() {
+  if (process && process.env.REACT_APP_LOCAL_ENV === 'true') {
+    return 'http://' + window.location.hostname + ':4000';
+  }
+  return 'https://api.susi.ai';
+}
+
 const urls = {
-  API_URL: process.env.REACT_APP_API_URL || 'https://api.susi.ai',
+  API_URL: check(),
   SOUND_SERVER_API_URL: 'http://0.0.0.0:7070',
   CHAT_URL: 'https://susi.ai/chat',
   SKILL_URL: 'https://susi.ai/skills',


### PR DESCRIPTION
Fixes #2769

Changes: Add a function which checks if `LOCAL_ENV` variable is `true` and use the correct API URL accordingly

Demo Link: https://pr-2804-fossasia-susi-web-chat.surge.sh



