### PR TITLE
SUSI Smart Speaker Device Control page independent of login #2784

### DIFF
--- a/src/components/cms/MyDevices/ControlSection.js
+++ b/src/components/cms/MyDevices/ControlSection.js
@@ -24,6 +24,7 @@ import Radio from '@material-ui/core/Radio';
 import RadioGroup from '@material-ui/core/RadioGroup';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
 import FormControl from '@material-ui/core/FormControl';
+import DialogContent from '@material-ui/core/DialogContent';
 import {
   resumeAction,
   pauseAction,
@@ -37,13 +38,7 @@ import {
   refreshDeviceList,
   setControlOptions,
 } from '../../../apis';
-import {
-  Section,
-  Overlay,
-  OverlayContainer,
-  ControlHeading,
-  FlexContainer,
-} from './styles';
+import { Section, Overlay, ControlHeading, FlexContainer } from './styles';
 
 class ControlSection extends React.Component {
   static propTypes = {
@@ -131,253 +126,256 @@ class ControlSection extends React.Component {
     } = this.state;
     const { isLocalEnv } = this.props;
     return (
-      <OverlayContainer>
+      <React.Fragment>
         {!isLocalEnv && (
           <Overlay>
             {/* You need to access this page on your device to control your device. */}
             Coming Soon
           </Overlay>
         )}
-        <h1>Controls</h1>
-        <Section>
-          <ControlHeading>Volume</ControlHeading>
-          <Grid container spacing={2}>
-            <Grid item>
-              <VolumeDown />
+        <h1 style={{ textAlign: 'center' }}>Controls</h1>
+        <DialogContent style={{ textAlign: 'left' }}>
+          <Section>
+            <ControlHeading>Volume</ControlHeading>
+            <Grid container spacing={2}>
+              <Grid item>
+                <VolumeDown />
+              </Grid>
+              <Grid item xs>
+                <Slider
+                  value={volume}
+                  valueLabelDisplay="auto"
+                  onChange={this.handleVolumeChange}
+                />
+              </Grid>
+              <Grid item>
+                <VolumeUp />
+              </Grid>
             </Grid>
-            <Grid item xs>
-              <Slider
-                value={volume}
-                valueLabelDisplay="auto"
-                onChange={this.handleVolumeChange}
+          </Section>
+          <Section>
+            <ControlHeading>Playback Control</ControlHeading>
+            <Grid container spacing={1}>
+              <Grid item>
+                <Button variant="outlined" onClick={pauseAction}>
+                  Pause
+                  <Pause />
+                </Button>
+              </Grid>
+              <Grid item>
+                <Button
+                  variant="outlined"
+                  color="inherit"
+                  onClick={resumeAction}
+                  style={{ color: 'green' }}
+                >
+                  Resume
+                  <PlayArrow />
+                </Button>
+              </Grid>
+              <Grid item>
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  onClick={restartAction}
+                >
+                  Restart
+                  <Replay />
+                </Button>
+              </Grid>
+              <Grid item>
+                <Button
+                  variant="outlined"
+                  color="inherit"
+                  onClick={stopAction}
+                  style={{ color: 'red' }}
+                >
+                  Stop
+                  <Stop />
+                </Button>
+              </Grid>
+              <Grid item>
+                <Button variant="outlined" onClick={previousAction}>
+                  Previous
+                  <SkipPrevious />
+                </Button>
+              </Grid>
+              <Grid item>
+                <Button
+                  variant="outlined"
+                  color="primary"
+                  onClick={shuffleAction}
+                >
+                  Shuffle
+                  <Shuffle />
+                </Button>
+              </Grid>
+              <Grid item>
+                <Button variant="outlined" onClick={nextAction}>
+                  Next
+                  <SkipNext />
+                </Button>
+              </Grid>
+            </Grid>
+          </Section>
+          <Section>
+            <ControlHeading>Play YouTube songs</ControlHeading>
+            <FlexContainer>
+              <OutlinedTextField
+                label="YouTube link"
+                placeholder="YouTube link"
+                value={youtubeLink || ''}
+                name="youtubeLink"
+                style={{ marginRight: '2rem', width: '80%' }}
+                onChange={this.handleChange}
               />
-            </Grid>
-            <Grid item>
-              <VolumeUp />
-            </Grid>
-          </Grid>
-        </Section>
-        <Section>
-          <ControlHeading>Playback Control</ControlHeading>
-          <Grid container spacing={2}>
-            <Grid item>
-              <Button variant="outlined" onClick={pauseAction}>
-                Pause
-                <Pause />
-              </Button>
-            </Grid>
-            <Grid item>
               <Button
                 variant="outlined"
                 color="inherit"
-                onClick={resumeAction}
+                disabled={!youtubeLink}
+                onClick={() => playInYoutubeAction({ youtubeLink })}
                 style={{ color: 'green' }}
               >
-                Resume
+                Play
                 <PlayArrow />
               </Button>
-            </Grid>
-            <Grid item>
-              <Button
-                variant="outlined"
-                color="primary"
-                onClick={restartAction}
+            </FlexContainer>
+          </Section>
+          <Section>
+            <ControlHeading>Play songs from your local device</ControlHeading>
+            <FlexContainer>
+              <Select
+                value={selectedDevice}
+                onChange={this.handleDeviceSelect}
+                style={{ marginRight: '2rem', width: '80%' }}
+                disabled={devicesList.length === 0}
+                input={<OutlinedTextField name="devices" />}
               >
-                Restart
-                <Replay />
-              </Button>
-            </Grid>
-            <Grid item>
-              <Button
-                variant="outlined"
-                color="inherit"
-                onClick={stopAction}
-                style={{ color: 'red' }}
-              >
-                Stop
-                <Stop />
-              </Button>
-            </Grid>
-            <Grid item>
-              <Button variant="outlined" onClick={previousAction}>
-                Previous
-                <SkipPrevious />
-              </Button>
-            </Grid>
-            <Grid item>
-              <Button
-                variant="outlined"
-                color="primary"
-                onClick={shuffleAction}
-              >
-                Shuffle
-                <Shuffle />
-              </Button>
-            </Grid>
-            <Grid item>
-              <Button variant="outlined" onClick={nextAction}>
-                Next
-                <SkipNext />
-              </Button>
-            </Grid>
-          </Grid>
-        </Section>
-        <Section>
-          <ControlHeading>Play YouTube songs</ControlHeading>
-          <OutlinedTextField
-            label="YouTube link"
-            placeholder="YouTube link"
-            value={youtubeLink || ''}
-            name="youtubeLink"
-            fullWidth
-            onChange={this.handleChange}
-          />
-          <Button
-            variant="outlined"
-            color="inherit"
-            disabled={!youtubeLink}
-            onClick={() => playInYoutubeAction({ youtubeLink })}
-            style={{ color: 'green' }}
-          >
-            Play
-            <PlayArrow />
-          </Button>
-        </Section>
-        <Section>
-          <ControlHeading>Play songs from your local device</ControlHeading>
-          <FlexContainer>
-            <Select
-              value={selectedDevice}
-              onChange={this.handleDeviceSelect}
-              fullWidth
-              style={{ marginRight: '2rem' }}
-              disabled={devicesList.length === 0}
-              input={<OutlinedTextField name="devices" />}
-            >
-              {devicesList.map((eachDevice, index) => (
-                <MenuItem key={index} value={eachDevice.name}>
-                  {eachDevice.name}
-                </MenuItem>
-              ))}
-            </Select>
-            <Fab color="primary" onClick={this.populateDeviceList}>
-              <Refresh />
-            </Fab>
-          </FlexContainer>
-        </Section>
+                {devicesList.map((eachDevice, index) => (
+                  <MenuItem key={index} value={eachDevice.name}>
+                    {eachDevice.name}
+                  </MenuItem>
+                ))}
+              </Select>
+              <Fab color="primary" onClick={this.populateDeviceList}>
+                <Refresh />
+              </Fab>
+            </FlexContainer>
+          </Section>
 
-        <Section>
-          <ControlHeading>Speech To Text(STT)</ControlHeading>
-          <FlexContainer>
-            <FormControl>
-              <RadioGroup
-                aria-label="stt"
-                name="stt"
-                value={stt}
-                onChange={this.handleRadioChange}
-              >
-                <FormControlLabel
-                  value="google"
-                  control={<Radio />}
-                  label="Google"
-                />
-                <FormControlLabel
-                  value="watson"
-                  control={<Radio />}
-                  label="Watson"
-                />
-                <FormControlLabel
-                  value="bing"
-                  control={<Radio />}
-                  label="Bing"
-                />
-                <FormControlLabel
-                  value="pocketsphinx"
-                  control={<Radio />}
-                  label="Pocket Sphinx"
-                />
-              </RadioGroup>
-            </FormControl>
-          </FlexContainer>
-        </Section>
-        <Section>
-          <ControlHeading>Text To Speech(TTS)</ControlHeading>
-          <FlexContainer>
-            <FormControl>
-              <RadioGroup
-                aria-label="tts"
-                name="tts"
-                value={tts}
-                onChange={this.handleRadioChange}
-              >
-                <FormControlLabel
-                  value="google"
-                  control={<Radio />}
-                  label="Google"
-                />
-                <FormControlLabel
-                  value="watson"
-                  control={<Radio />}
-                  label="Watson"
-                />
-                <FormControlLabel
-                  value="flite"
-                  control={<Radio />}
-                  label="Flite"
-                />
-              </RadioGroup>
-            </FormControl>
-          </FlexContainer>
-        </Section>
-        <Section>
-          <ControlHeading>Set Hotword Engine</ControlHeading>
-          <FlexContainer>
-            <FormControl>
-              <RadioGroup
-                aria-label="Hotword"
-                name="hotword"
-                value={hotword}
-                onChange={this.handleRadioChange}
-              >
-                <FormControlLabel
-                  value="Snowboy"
-                  control={<Radio />}
-                  label="Snowboy"
-                />
-                <FormControlLabel
-                  value="PocketSphinx"
-                  control={<Radio />}
-                  label="Pocket Sphinx"
-                />
-              </RadioGroup>
-            </FormControl>
-          </FlexContainer>
-        </Section>
-        <Section>
-          <ControlHeading>Wake Button</ControlHeading>
-          <FlexContainer>
-            <FormControl>
-              <RadioGroup
-                aria-label="wake-button"
-                name="wake"
-                value={wake}
-                onChange={this.handleRadioChange}
-              >
-                <FormControlLabel
-                  value="y"
-                  control={<Radio />}
-                  label="Enable"
-                />
-                <FormControlLabel
-                  value="n"
-                  control={<Radio />}
-                  label="Disable"
-                />
-              </RadioGroup>
-            </FormControl>
-          </FlexContainer>
-        </Section>
-      </OverlayContainer>
+          <Section>
+            <ControlHeading>Speech To Text(STT)</ControlHeading>
+            <FlexContainer>
+              <FormControl>
+                <RadioGroup
+                  aria-label="stt"
+                  name="stt"
+                  value={stt}
+                  onChange={this.handleRadioChange}
+                >
+                  <FormControlLabel
+                    value="google"
+                    control={<Radio />}
+                    label="Google"
+                  />
+                  <FormControlLabel
+                    value="watson"
+                    control={<Radio />}
+                    label="Watson"
+                  />
+                  <FormControlLabel
+                    value="bing"
+                    control={<Radio />}
+                    label="Bing"
+                  />
+                  <FormControlLabel
+                    value="pocketsphinx"
+                    control={<Radio />}
+                    label="Pocket Sphinx"
+                  />
+                </RadioGroup>
+              </FormControl>
+            </FlexContainer>
+          </Section>
+          <Section>
+            <ControlHeading>Text To Speech(TTS)</ControlHeading>
+            <FlexContainer>
+              <FormControl>
+                <RadioGroup
+                  aria-label="tts"
+                  name="tts"
+                  value={tts}
+                  onChange={this.handleRadioChange}
+                >
+                  <FormControlLabel
+                    value="google"
+                    control={<Radio />}
+                    label="Google"
+                  />
+                  <FormControlLabel
+                    value="watson"
+                    control={<Radio />}
+                    label="Watson"
+                  />
+                  <FormControlLabel
+                    value="flite"
+                    control={<Radio />}
+                    label="Flite"
+                  />
+                </RadioGroup>
+              </FormControl>
+            </FlexContainer>
+          </Section>
+          <Section>
+            <ControlHeading>Set Hotword Engine</ControlHeading>
+            <FlexContainer>
+              <FormControl>
+                <RadioGroup
+                  aria-label="Hotword"
+                  name="hotword"
+                  value={hotword}
+                  onChange={this.handleRadioChange}
+                >
+                  <FormControlLabel
+                    value="Snowboy"
+                    control={<Radio />}
+                    label="Snowboy"
+                  />
+                  <FormControlLabel
+                    value="PocketSphinx"
+                    control={<Radio />}
+                    label="Pocket Sphinx"
+                  />
+                </RadioGroup>
+              </FormControl>
+            </FlexContainer>
+          </Section>
+          <Section>
+            <ControlHeading>Wake Button</ControlHeading>
+            <FlexContainer>
+              <FormControl>
+                <RadioGroup
+                  aria-label="wake-button"
+                  name="wake"
+                  value={wake}
+                  onChange={this.handleRadioChange}
+                >
+                  <FormControlLabel
+                    value="y"
+                    control={<Radio />}
+                    label="Enable"
+                  />
+                  <FormControlLabel
+                    value="n"
+                    control={<Radio />}
+                    label="Disable"
+                  />
+                </RadioGroup>
+              </FormControl>
+            </FlexContainer>
+          </Section>
+        </DialogContent>
+      </React.Fragment>
     );
   }
 }

--- a/src/components/cms/MyDevices/DeviceWizard.js
+++ b/src/components/cms/MyDevices/DeviceWizard.js
@@ -10,7 +10,7 @@ import { GoogleApiWrapper } from 'google-maps-react';
 import CircularLoader from '../../shared/CircularLoader';
 import ControlSection from './ControlSection';
 import ConfigureSection from './ConfigureSection';
-import { Paper, ErrorText } from './styles';
+import { Paper, ErrorText, OverlayContainer } from './styles';
 
 class DeviceWizard extends React.Component {
   static propTypes = {
@@ -217,7 +217,9 @@ class DeviceWizard extends React.Component {
               handleChangeSpeech={this.handleChangeSpeech}
               handleRemoveConfirmation={this.handleRemoveConfirmation}
             />
-            <ControlSection />
+            <OverlayContainer>
+              <ControlSection />
+            </OverlayContainer>
           </div>
         ) : (
           <ErrorText>

--- a/src/components/shared/AppBanner.js
+++ b/src/components/shared/AppBanner.js
@@ -1,4 +1,8 @@
 import React from 'react';
+import { connect } from 'react-redux';
+import PropTypes from 'prop-types';
+import uiActions from '../../redux/actions/ui';
+import { bindActionCreators } from 'redux';
 import styled from 'styled-components';
 
 const Container = styled.div`
@@ -14,13 +18,38 @@ const Container = styled.div`
   height: 40px;
 `;
 
-const AppBanner = () => {
+const ConfigureSpan = styled.span`
+  text-decoration: underline;
+  margin-left: 4px;
+  cursor: pointer;
+`;
+
+const AppBanner = ({ actions }) => {
+  const openControlPage = () => {
+    actions.openModal({
+      modalType: 'deviceControlSettings',
+    });
+  };
   return (
     <Container>
       You are currently accessing the local version of your SUSI.AI running on
-      your smart device
+      your smart device.
+      <ConfigureSpan onClick={openControlPage}>Configure now</ConfigureSpan>
     </Container>
   );
 };
 
-export default AppBanner;
+AppBanner.propTypes = {
+  actions: PropTypes.object,
+};
+
+function mapDispatchToProps(dispatch) {
+  return {
+    actions: bindActionCreators(uiActions, dispatch),
+  };
+}
+
+export default connect(
+  null,
+  mapDispatchToProps,
+)(AppBanner);

--- a/src/components/shared/Dialog/index.js
+++ b/src/components/shared/Dialog/index.js
@@ -29,6 +29,7 @@ import StandardActionDialog from './dialogTypes/StandardActionDialog';
 import ChatApp from '../../ChatApp/ChatApp.react';
 import AddDeviceDialog from '../../cms/MyDevices/AddDeviceDialog';
 import ResetPasswordDialog from '../../Auth/ResetPassword';
+import DeviceContolDialog from '../../cms/MyDevices/ControlSection';
 import isMobileView from '../../../utils/isMobileView';
 import { withRouter } from 'react-router-dom';
 
@@ -100,6 +101,10 @@ const DialogData = {
   resetPass: {
     Component: ResetPasswordDialog,
     size: 'sm',
+  },
+  deviceControlSettings: {
+    Component: DeviceContolDialog,
+    size: 'md',
   },
 };
 

--- a/src/index.js
+++ b/src/index.js
@@ -39,8 +39,18 @@ let piwik = null,
 
 let usepiwik = false;
 fetchApiKeys().then(payload => {
-  matomoSiteId = payload.keys.matomoSiteId.value || '';
-  matomoUrl = payload.keys.matomoUrl.value || '';
+  matomoSiteId =
+    (payload &&
+      payload.keys &&
+      payload.keys.matomoSiteId &&
+      payload.keys.matomoSiteId.value) ||
+    '';
+  matomoUrl =
+    (payload &&
+      payload.keys &&
+      payload.keys.matomoUrl &&
+      payload.keys.matomoUrl.value) ||
+    '';
   piwik = new ReactPiwik({
     url: matomoUrl || '',
     siteId: matomoSiteId || '',


### PR DESCRIPTION
Fixes #2784

Changes: Make SUSI Smart Speaker Device Control page independent of login

Demo Link: https://pr-2820-fossasia-susi-web-chat.surge.sh

Screenshots of the change:

<img width="971" alt="Screenshot 2019-08-11 at 3 10 22 PM" src="https://user-images.githubusercontent.com/18073126/62832357-4acc1000-bc4a-11e9-9c48-7b5f9d7eaa56.png">

<img width="969" alt="Screenshot 2019-08-11 at 3 10 29 PM" src="https://user-images.githubusercontent.com/18073126/62832358-4b64a680-bc4a-11e9-8fde-41ea1a81763f.png">

<img width="912" alt="Screenshot 2019-08-11 at 3 01 47 PM" src="https://user-images.githubusercontent.com/18073126/62832245-fa07e780-bc48-11e9-98ab-1b4d7ebfd048.png">


