### PR TITLE
Load groups action failed + Cannot read property 'staffPicks' of undefined

### DIFF
--- a/src/components/cms/BrowseSkill/BrowseSkill.js
+++ b/src/components/cms/BrowseSkill/BrowseSkill.js
@@ -403,7 +403,7 @@ class BrowseSkill extends React.Component {
     const { groups } = this.props;
     if (groups.length === 0) {
       this.props.actions.getGroupOptions().catch(error => {
-        throw new Error('load groups action failed');
+        console.log(error);
       });
     }
   };

--- a/src/redux/reducers/skills.js
+++ b/src/redux/reducers/skills.js
@@ -63,16 +63,18 @@ export default handleActions(
     },
     [actionTypes.SKILLS_GET_METRICS_SKILLS](state, { payload }) {
       const { metrics } = payload;
-      const metricSkills = {
-        staffPicksSkills: metrics.staffPicks,
-        topRatedSkills: metrics.rating,
-        topUsedSkills: metrics.usage,
-        latestUpdatedSkills: metrics.latest,
-        newestSkills: metrics.newest,
-        topFeedbackSkills: metrics.feedback,
-        topGames: metrics.gamesTriviaAndAccessories,
-        systemSkills: metrics.systemSkills,
-      };
+      const metricSkills = metrics
+        ? {
+            staffPicksSkills: metrics.staffPicks,
+            topRatedSkills: metrics.rating,
+            topUsedSkills: metrics.usage,
+            latestUpdatedSkills: metrics.latest,
+            newestSkills: metrics.newest,
+            topFeedbackSkills: metrics.feedback,
+            topGames: metrics.gamesTriviaAndAccessories,
+            systemSkills: metrics.systemSkills,
+          }
+        : {};
       return {
         ...state,
         metricSkills,


### PR DESCRIPTION
Fixes #2826 

Changes: Replaced `throw new Error` with console.log
`metricSkills ` will be an empty object is `metrics` from  payload is undefined.

Demo Link: https://pr-2855-fossasia-susi-web-chat.surge.sh