### PR TITLE
Center aligned my analytics text

### DIFF
--- a/src/components/cms/Dashboard/MyAnalytics.js
+++ b/src/components/cms/Dashboard/MyAnalytics.js
@@ -99,7 +99,7 @@ class MyAnalytics extends Component {
           <Container>
             <div className="center">
               <br />
-              <h2>
+              <h2 style={{textAlign:'center'}}>
                 Your skill has not been used, make sure to improve your skill to
                 attract more users.
               </h2>

--- a/src/components/cms/Dashboard/MyAnalytics.js
+++ b/src/components/cms/Dashboard/MyAnalytics.js
@@ -99,7 +99,7 @@ class MyAnalytics extends Component {
           <Container>
             <div className="center">
               <br />
-              <h2 style={{ textAlign:'center' }}>
+              <h2 style={{ textAlign: 'center' }}>
                 Your skill has not been used, make sure to improve your skill to
                 attract more users.
               </h2>

--- a/src/components/cms/Dashboard/MyAnalytics.js
+++ b/src/components/cms/Dashboard/MyAnalytics.js
@@ -99,7 +99,7 @@ class MyAnalytics extends Component {
           <Container>
             <div className="center">
               <br />
-              <h2 style={{textAlign:'center'}}>
+              <h2 style={{ textAlign:'center' }}>
                 Your skill has not been used, make sure to improve your skill to
                 attract more users.
               </h2>


### PR DESCRIPTION
Fixes #2915 

Changes: Center aligned the text "Your skill has not been used, make sure to improve your skill to attract more users." when no analytics are there to show.

Demo Link: https://pr-[ADD_PULL_REQUEST_NUMBER_HERE]-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
**Before**
![analytics](https://user-images.githubusercontent.com/45489945/65431732-907a1c00-de37-11e9-8cd3-6aac83e86706.png)

**After**
![nnn](https://user-images.githubusercontent.com/45489945/65519800-35fac180-df04-11e9-8926-44249cacd614.png)
