### PR TITLE
Set "default" avatar selected by default

### DIFF
--- a/src/redux/reducers/settings.js
+++ b/src/redux/reducers/settings.js
@@ -75,7 +75,7 @@ export default handleActions(
         checked = config.checked,
         backgroundImage = config.backgroundImage,
         messageBackgroundImage = config.messageBackgroundImage,
-        avatarType = config.messageBackgroundImage,
+        avatarType = config.avatarType,
       } = settings;
       let { customThemeValue } = settings;
       const themeArray = customThemeValue


### PR DESCRIPTION
Fixes #2919 

Changes: Set the default avatar as "default" when initially no avatar is selected by a new user.

Demo Link: https://pr-2927-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
**Before**
![im2](https://user-images.githubusercontent.com/45489945/65608078-44f87700-dfcb-11e9-93d0-02cbdaa35569.png)

**After**
![im1](https://user-images.githubusercontent.com/45489945/65608104-4e81df00-dfcb-11e9-82bb-f71da5e3349e.png)

