### PR TITLE
Color reset bug solved

### DIFF
--- a/src/components/shared/ColorPickerComponent/index.js
+++ b/src/components/shared/ColorPickerComponent/index.js
@@ -40,7 +40,7 @@ const ColorPickerComponent = props => {
         <ColorPicker
           name="color"
           id={'colorPicker' + id}
-          defaultValue={backgroundColor}
+          value={backgroundColor}
           onChange={color => handleChangeColor(component, color)}
         />
       </ColorPickerContainer>


### PR DESCRIPTION
Fixes #2935 

Changes: The colorValue was not getting reset as its value was initially set to `defaultValue` instead of just `value`.

Demo Link: https://pr-2939-fossasia-susi-web-chat.surge.sh

Screenshots of the change:

![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/45489945/66381397-dd80f500-e9d6-11e9-98bb-58e9ae62dfdd.gif)

