### PR TITLE
Fixing save changes issue in theme settings

### DIFF
--- a/src/components/Settings/ThemeChangeTab.react.js
+++ b/src/components/Settings/ThemeChangeTab.react.js
@@ -30,6 +30,7 @@ class ThemeChangeTab extends React.Component {
   handleSubmit = async () => {
     const { actions, theme, userEmailId } = this.props;
     this.setState({ loading: true });
+    this.initialTheme = theme;
     let payload = {
       theme,
     };


### PR DESCRIPTION
Fixes #2924

Changes:
**ThemeChangerTab.react.js** - Changed the value of the initialTheme variable so that it's updated to the newly saved theme accordingly. 

Screenshots of the change: 
![DisablingSaveButtonOnSave](https://user-images.githubusercontent.com/31003923/66856825-a8ab0a00-efa3-11e9-9bf0-665bc27cafeb.gif)


