### PR TITLE
Fixes edit feedback issue 

### DIFF
--- a/src/components/ChatApp/MessageListItem/generateMessageBubbleUtil.js
+++ b/src/components/ChatApp/MessageListItem/generateMessageBubbleUtil.js
@@ -90,6 +90,7 @@ const generateDateBubble = message => {
   );
 };
 
+/*
 const generateGifBubble = (
   action,
   index,
@@ -114,6 +115,7 @@ const generateGifBubble = (
     </MessageContainer>
   );
 };
+*/
 
 const generateAnswerBubble = (
   action,
@@ -366,17 +368,17 @@ export const generateMessageBubble = (
           );
         } else {
         */
-          listItems.push(
-            generateAnswerBubble(
-              actionType,
-              index,
-              replacedText,
-              message,
-              latestUserMsgID,
-              showFeedback,
-            ),
-          );
-        //}
+        listItems.push(
+          generateAnswerBubble(
+            actionType,
+            index,
+            replacedText,
+            message,
+            latestUserMsgID,
+            showFeedback,
+          ),
+        );
+        // }
         break;
       }
       case 'anchor': {

--- a/src/components/cms/SkillFeedbackCard/SkillFeedbackCard.js
+++ b/src/components/cms/SkillFeedbackCard/SkillFeedbackCard.js
@@ -63,15 +63,17 @@ class SkillFeedbackCard extends Component {
     this.setState({ newFeedbackValue: event.target.value });
   };
 
-  handleEditOpen = () => {
+  handleEditOpen = previousFeedback => {
     this.handleMenuClose();
-    this.props.actions.openModal({
-      modalType: 'editFeedback',
-      handleConfirm: this.postFeedback,
-      handleClose: this.props.actions.closeModal,
-      errorText: this.state.errorText,
-      feedback: this.state.newFeedbackValue,
-      handleEditFeedback: this.editFeedback,
+    this.setState({ newFeedbackValue: previousFeedback }, () => {
+      this.props.actions.openModal({
+        modalType: 'editFeedback',
+        handleConfirm: this.postFeedback,
+        handleClose: this.props.actions.closeModal,
+        errorText: this.state.errorText,
+        feedback: this.state.newFeedbackValue,
+        handleEditFeedback: this.editFeedback,
+      });
     });
   };
 
@@ -115,6 +117,7 @@ class SkillFeedbackCard extends Component {
 
   deleteFeedback = async () => {
     const { group, language, skillTag: skill, actions } = this.props;
+    this.setState({ newFeedbackValue: '' });
     const skillData = {
       model: 'general',
       group,
@@ -182,7 +185,11 @@ class SkillFeedbackCard extends Component {
                     open={open}
                     onClose={this.handleMenuClose}
                   >
-                    <MenuItem onClick={this.handleEditOpen}>
+                    <MenuItem
+                      onClick={() => {
+                        this.handleEditOpen(data.feedback);
+                      }}
+                    >
                       <ListItemIcon>
                         <EditBtn />
                       </ListItemIcon>

--- a/src/components/shared/Dialog/index.js
+++ b/src/components/shared/Dialog/index.js
@@ -20,7 +20,7 @@ import EditSkill from '../../Admin/ListSkills/EditSkillDialog';
 import EditDevice from '../../Admin/ListDevices/EditDeviceDialog';
 import ConfirmDialog from './dialogTypes/ConfirmDialog';
 import ReportSkillDialog from '../../cms/SkillPage/ReportSkillDialog';
-import EditFeedbackDialog from '../../cms/SkillFeedbackPage/EditFeedbackDialog';
+import EditFeedback from '../../cms/SkillFeedbackPage/EditFeedbackDialog';
 import SkillSlideshowDialog from '../../Admin/Settings/Slideshow/Dialog';
 import EditUserRole from '../../Admin/ListUser/EditUserRoleDialog';
 import DeleteUserAccountDialog from '../../Admin/ListUser/DeleteDialog';
@@ -80,7 +80,11 @@ const DialogData = {
     size: 'sm',
     componentProps: { entityType: 'feedback', actionType: 'Delete' },
   },
-  editFeedback: { Component: EditFeedbackDialog, size: 'sm' },
+  editFeedback: {
+    Component: EditFeedback,
+    size: 'sm',
+    componentProps: { entityType: 'feedback', actionType: 'Edit' },
+  },
   // For skillCreator delete skill
   deleteBot: {
     Component: ConfirmDeleteWithInput,


### PR DESCRIPTION
Fixes #2948 

Changes: 
**In SkillFeedbackCard.js**
-A `componentDidMount` life cycle hook is used to intialise the `newFeedbackValue` to the previous feedback submitted by the user.

**In index.js**
-`EditFeedbackDialog` component was imported from `EditFeedbackDialog.js` instead of `EditFeedback`.
Demo Link: https://pr-2956-fossasia-susi-web-chat.surge.sh


