### PR TITLE
Fixes 2808 - Adding Rating to Skill feedback page

### DIFF
--- a/src/components/cms/SkillFeedbackPage/SkillFeedbackPage.js
+++ b/src/components/cms/SkillFeedbackPage/SkillFeedbackPage.js
@@ -24,6 +24,7 @@ import EditBtn from '@material-ui/icons/BorderColor';
 import NavigationChevronRight from '@material-ui/icons/ChevronRight';
 import Emoji from 'react-emoji-render';
 import styled, { css } from 'styled-components';
+import SkillRatingCard from '../SkillRating/SkillRatingCard';
 
 import { parseDate, formatDate } from '../../../utils';
 import getImageSrc from '../../../utils/getImageSrc';
@@ -610,6 +611,9 @@ class SkillFeedbackPage extends Component {
                 </div>
               </div>
             </SkillDetailContainer>
+          </Paper>
+          <SkillRatingCard />
+          <Paper>
             <Title marginTop>Feedback</Title>
             {feedbackCardsElement}
             {skillFeedbacks &&


### PR DESCRIPTION
Fixes #2808 

Changes:
**SkillFeedbackpage.js** - Added the skillratingcard component to the skillfeedback page.

Demo Link: http://penitent-oatmeal.surge.sh/

Screenshots of the change: [Add screenshots depicting the changes.]

![RatingComp](https://user-images.githubusercontent.com/31003923/67163650-0a49ea80-f38f-11e9-85a7-c4a082b7fb99.gif)
