### PR TITLE
Fixes 2975 - Restyled AppBar for mobileviews with small width

### DIFF
--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -586,7 +586,11 @@ class NavigationBar extends Component {
                           <UserDetail>
                             {!userName ? email : userName}
                           </UserDetail>
-                          <ExpandMore />
+                          <ExpandMore
+                            style={{
+                              display: isMobileView(400) ? 'none' : 'inline',
+                            }}
+                          />
                         </FlexContainer>
                       </div>
                     </StyledIconButton>
@@ -636,9 +640,16 @@ class NavigationBar extends Component {
                           </Paper>
                         </Popper>
                         {isMobileView(400) ? (
-                          <Add />
+                          <Add
+                            style={{
+                              marginLeft: '5px',
+                              color: '#fff',
+                            }}
+                          />
                         ) : (
-                          <CreateDetail>Create</CreateDetail>
+                          <CreateDetail style={{ marginLeft: '20px' }}>
+                            Create
+                          </CreateDetail>
                         )}
                       </div>
                     </StyledIconButton>


### PR DESCRIPTION
Fixes #2975 

Changes: 
1) The "ExpandMore" icon is now displayed only in screen widths above 400. 
2) Added some margin to the left of the "CreateDetail" button.
3) Changed the color of the "Add" icon to white.

Screenshots of the change:

For the context this was how the AppBar looked **previously**

![Phone4](https://user-images.githubusercontent.com/31003923/67202502-6449bf00-f426-11e9-8f76-2c1d31f32b67.png)

This is how the it will look in different widths with the changes.(The width is at the top of the image).

![Phone1](https://user-images.githubusercontent.com/31003923/67202550-7f1c3380-f426-11e9-9da1-9d109abee4e5.png)

![Phone2](https://user-images.githubusercontent.com/31003923/67202567-8b07f580-f426-11e9-8491-345780cbcbe5.png)

![Phone3](https://user-images.githubusercontent.com/31003923/67202583-978c4e00-f426-11e9-934f-4fad19267fa8.png)


Demo Link: http://ruddy-cow.surge.sh/



