### PR TITLE
Fixes 2977 - Making the settings page scrollable

### DIFF
--- a/src/components/Settings/AccountTab.react.js
+++ b/src/components/Settings/AccountTab.react.js
@@ -35,7 +35,7 @@ const TimezoneContainer = styled.div`
 `;
 
 const Timezone = styled.div`
-  position: absolute;
+  position: relative;
   z-index: 99;
 `;
 

--- a/src/components/Settings/Settings.react.js
+++ b/src/components/Settings/Settings.react.js
@@ -49,7 +49,7 @@ const settingsOptions = [
 const Container = styled.div`
   width: 100%;
   min-height: calc(100vh - 48px);
-  overflow: hidden;
+  overflow: scroll;
   margin-top: 2rem;
   background: ${props => (props.theme === 'dark' ? '#000012' : '#f2f2f2')};
   @media only screen and (max-width: 1060px) {


### PR DESCRIPTION
Fixes #2977 

Changes: 
1) Changed the overflow property of the root container in settings page from 'hidden' to 'scroll', enabling the page to be scrolled.
2) Changed the position property of the Timezone styled component from absolute to relative. 

Demo Link: http://enchanting-run.surge.sh/

Screenshots of the change:

![ScrollableSettings](https://user-images.githubusercontent.com/31003923/67259214-3f029280-f4b2-11e9-8c85-73d60a312d6e.gif)



