### PR TITLE
Fixes 2980 - Fixing issues with the empty username field in Account tab

### DIFF
--- a/src/components/Settings/AccountTab.react.js
+++ b/src/components/Settings/AccountTab.react.js
@@ -247,9 +247,24 @@ class AccountTab extends React.Component {
     });
   };
 
+  isUserNameEntered = () => {
+    if (document.getElementById('userNameField').value.length === 0) {
+      this.setState({
+        userNameError:
+          'A valid username is required before setting timezone or preferred language!',
+      });
+      return false;
+    }
+    return true;
+  };
+
   handleSubmit = async () => {
     const { timeZone, prefLanguage, userName, avatarType } = this.state;
     const { actions, userEmailId } = this.props;
+
+    if (!this.isUserNameEntered()) {
+      return;
+    }
     let payload = {
       timeZone,
       prefLanguage,
@@ -362,8 +377,12 @@ class AccountTab extends React.Component {
                 aria-describedby="email-error-text"
                 style={{ width: '16rem', height: '2.1rem' }}
                 placeholder="Enter your User Name"
+                id="userNameField"
               />
-              <FormHelperText error={userNameError !== ''}>
+              <FormHelperText
+                error={userNameError !== ''}
+                style={{ maxWidth: '250px' }}
+              >
                 {userNameError}
               </FormHelperText>
             </FormControl>


### PR DESCRIPTION
Fixes #2980

Changes: 
Added additional validation so that the request is only sent after the username field is filled in(when a valid username is not set).

Demo Link :http://mighty-slip.surge.sh/

Screenshots of the change:
![SavingAccountSettings](https://user-images.githubusercontent.com/31003923/67360877-adb02080-f584-11e9-8f44-35a074b78638.gif)


