### PR TITLE
Only set loadingdrafts to false when there are no drafts to display

### DIFF
--- a/src/components/cms/BotBuilder/BotBuilder.js
+++ b/src/components/cms/BotBuilder/BotBuilder.js
@@ -287,10 +287,12 @@ class BotBuilder extends React.Component {
       const { drafts } = payload;
       this.showDrafts(drafts);
     } catch (error) {
-      actions.openSnackBar({
-        snackBarMessage: "Couldn't get your drafts. Please reload the page.",
-        snackBarDuration: 2000,
-      });
+      if (error.status !== 404) {
+        actions.openSnackBar({
+          snackBarMessage: "Couldn't get your drafts. Please reload the page.",
+          snackBarDuration: 2000,
+        });
+      }
       this.setState({
         loadingDrafts: false,
       });
@@ -346,6 +348,10 @@ class BotBuilder extends React.Component {
         );
       }
       this.setState({ drafts: draftsOfBots, loadingDrafts: false });
+    } else {
+      this.setState({
+        loadingDrafts: false,
+      });
     }
   };
 


### PR DESCRIPTION
Fixes #2983 

Changes: 
-Added an `else` statement in `showDrafts()` to only set `loadingDrafts` to false when there are no drafts. 
-In `getDrafts()` it jumps to `catch()` only when error occurs while receiving the `promise` in `let payload = await readDraft()`.

Demo Link: https://pr-2984-fossasia-susi-web-chat.surge.sh
