### PR TITLE
updated chat urls to susi.ai

### DIFF
--- a/src/utils/urls.js
+++ b/src/utils/urls.js
@@ -10,8 +10,8 @@ function getApiServerURL() {
 const urls = {
   API_URL: getApiServerURL(),
   SOUND_SERVER_API_URL: `${localHost}:7070`,
-  CHAT_URL: 'https://susi.ai/chat',
-  SKILL_URL: 'https://susi.ai/skills',
+  CHAT_URL: 'https://susi.ai',
+  SKILL_URL: 'https://susi.ai',
   HOME_URL: 'https://susi.ai',
   GITHUB_URL: 'https://github.com/fossasia/susi.ai',
   GITHUB_AVATAR_URL: 'https://avatars.githubusercontent.com',


### PR DESCRIPTION
Fixes #2986 

Changes: 
-Changed all urls https://susi.ai/chat  and  https://susi.ai/skills -> https://susi.ai

Demo Link: https://pr-2988-fossasia-susi-web-chat.surge.sh

