### PR TITLE
Fixes #2990: Hide table headers when there are no values to show

### DIFF
--- a/src/components/cms/Dashboard/MyRatings.js
+++ b/src/components/cms/Dashboard/MyRatings.js
@@ -81,49 +81,51 @@ class MyRatings extends Component {
           <CircularLoader height={5} />
         ) : (
           <TableWrap>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Skill Name</TableCell>
-                  <TableCell>Rating</TableCell>
-                  <TableCell>Timestamp</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {ratingsData.map((skill, index) => {
-                  const {
-                    group,
-                    skillName,
-                    ratingTimestamp,
-                    skillStar,
-                  } = skill;
-                  return (
-                    <TableRow key={index}>
-                      <StyledTableCell style={{ fontSize: '1rem' }}>
-                        <Link
-                          to={{
-                            pathname: `/${group}/${skillName
-                              .toLowerCase()
-                              .replace(/ /g, '_')}/language`,
-                          }}
-                        >
-                          {(
-                            skillName.charAt(0).toUpperCase() +
-                            skillName.slice(1)
-                          ).replace(/[_-]/g, ' ')}
-                        </Link>
-                      </StyledTableCell>
-                      <StyledTableCell style={{ fontSize: '1rem' }}>
-                        {skillStar}
-                      </StyledTableCell>
-                      <StyledTableCell>
-                        {parseDate(ratingTimestamp)}
-                      </StyledTableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
+            {ratingsData.length !== 0 && (
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Skill Name</TableCell>
+                    <TableCell>Rating</TableCell>
+                    <TableCell>Timestamp</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {ratingsData.map((skill, index) => {
+                    const {
+                      group,
+                      skillName,
+                      ratingTimestamp,
+                      skillStar,
+                    } = skill;
+                    return (
+                      <TableRow key={index}>
+                        <StyledTableCell style={{ fontSize: '1rem' }}>
+                          <Link
+                            to={{
+                              pathname: `/${group}/${skillName
+                                .toLowerCase()
+                                .replace(/ /g, '_')}/language`,
+                            }}
+                          >
+                            {(
+                              skillName.charAt(0).toUpperCase() +
+                              skillName.slice(1)
+                            ).replace(/[_-]/g, ' ')}
+                          </Link>
+                        </StyledTableCell>
+                        <StyledTableCell style={{ fontSize: '1rem' }}>
+                          {skillStar}
+                        </StyledTableCell>
+                        <StyledTableCell>
+                          {parseDate(ratingTimestamp)}
+                        </StyledTableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            )}
           </TableWrap>
         )}
         {ratingsData.length === 0 && !loading && (

--- a/src/components/cms/Dashboard/MySkills.js
+++ b/src/components/cms/Dashboard/MySkills.js
@@ -109,51 +109,29 @@ class MySkills extends Component {
           <CircularLoader height={5} />
         ) : (
           <TableWrap>
-            <Table>
-              <TableHead>
-                <TableRow>
-                  <TableCell>Image</TableCell>
-                  <TableCell>Name</TableCell>
-                  <TableCell>Type</TableCell>
-                  <TableCell>Status</TableCell>
-                </TableRow>
-              </TableHead>
-              <TableBody>
-                {userSkills.map((skill, index) => {
-                  const {
-                    group,
-                    skillTag,
-                    language,
-                    image,
-                    skillName,
-                    type,
-                  } = skill;
-                  return (
-                    <TableRow key={index}>
-                      <StyledTableCell>
-                        <Link
-                          to={{
-                            pathname: `/${group}/${skillTag
-                              .toLowerCase()
-                              .replace(/ /g, '_')}/${language}`,
-                          }}
-                        >
-                          <Img
-                            // eslint-disable-next-line
-                            src={getImageSrc({
-                              relativePath: `model=general&language=${language}&group=${group.replace(
-                                / /g,
-                                '%20',
-                              )}&image=/${image}`,
-                            })}
-                            unloader={
-                              <CircleImage name={skillName} size="40" />
-                            }
-                          />
-                        </Link>
-                      </StyledTableCell>
-                      <StyledTableCell style={{ fontSize: '1rem' }}>
-                        {skillName ? (
+            {userSkills.length !== 0 && (
+              <Table>
+                <TableHead>
+                  <TableRow>
+                    <TableCell>Image</TableCell>
+                    <TableCell>Name</TableCell>
+                    <TableCell>Type</TableCell>
+                    <TableCell>Status</TableCell>
+                  </TableRow>
+                </TableHead>
+                <TableBody>
+                  {userSkills.map((skill, index) => {
+                    const {
+                      group,
+                      skillTag,
+                      language,
+                      image,
+                      skillName,
+                      type,
+                    } = skill;
+                    return (
+                      <TableRow key={index}>
+                        <StyledTableCell>
                           <Link
                             to={{
                               pathname: `/${group}/${skillTag
@@ -161,27 +139,51 @@ class MySkills extends Component {
                                 .replace(/ /g, '_')}/${language}`,
                             }}
                           >
-                            {skillName}
+                            <Img
+                              // eslint-disable-next-line
+                              src={getImageSrc({
+                                relativePath: `model=general&language=${language}&group=${group.replace(
+                                  / /g,
+                                  '%20',
+                                )}&image=/${image}`,
+                              })}
+                              unloader={
+                                <CircleImage name={skillName} size="40" />
+                              }
+                            />
                           </Link>
-                        ) : (
-                          'NA'
-                        )}
-                      </StyledTableCell>
-                      <StyledTableCell style={{ fontSize: '1rem' }}>
-                        {type}
-                      </StyledTableCell>
-                      <StyledTableCell style={{ width: '10rem' }}>
-                        <FormControl>
-                          <Select value={1} style={{ width: '10rem' }}>
-                            <MenuItem value={1}>Enable</MenuItem>
-                          </Select>
-                        </FormControl>
-                      </StyledTableCell>
-                    </TableRow>
-                  );
-                })}
-              </TableBody>
-            </Table>
+                        </StyledTableCell>
+                        <StyledTableCell style={{ fontSize: '1rem' }}>
+                          {skillName ? (
+                            <Link
+                              to={{
+                                pathname: `/${group}/${skillTag
+                                  .toLowerCase()
+                                  .replace(/ /g, '_')}/${language}`,
+                              }}
+                            >
+                              {skillName}
+                            </Link>
+                          ) : (
+                            'NA'
+                          )}
+                        </StyledTableCell>
+                        <StyledTableCell style={{ fontSize: '1rem' }}>
+                          {type}
+                        </StyledTableCell>
+                        <StyledTableCell style={{ width: '10rem' }}>
+                          <FormControl>
+                            <Select value={1} style={{ width: '10rem' }}>
+                              <MenuItem value={1}>Enable</MenuItem>
+                            </Select>
+                          </FormControl>
+                        </StyledTableCell>
+                      </TableRow>
+                    );
+                  })}
+                </TableBody>
+              </Table>
+            )}
           </TableWrap>
         )}
         {userSkills.length === 0 && !loading && (


### PR DESCRIPTION
Fixes #2990 

Changes: 
Updated the `MyRatings.js` and `MySkills.js` to hide table headers when there are no ratings or skills of the user to display.

Demo Link: https://pr-2991-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
**Before**
![ddd](https://user-images.githubusercontent.com/45489945/67491030-da9e2980-f691-11e9-9ccc-4e57c497b1e6.png)

**After**
![cdc](https://user-images.githubusercontent.com/45489945/67515750-e81cd900-f6bc-11e9-8d49-6aba53f32762.png)
