### PR TITLE
Center aligned no skills text

### DIFF
--- a/src/components/cms/BrowseSkill/BrowseSkill.js
+++ b/src/components/cms/BrowseSkill/BrowseSkill.js
@@ -617,7 +617,8 @@ class BrowseSkill extends React.Component {
     let metricsHidden =
       routeType || searchQuery.length > 0 || ratingRefine || timeFilter;
 
-    let renderSkillCount = '';
+    let renderSkillCount = '',
+      noSkillFound = '';
     if (skills.length > 0) {
       renderSkillCount = (
         <div
@@ -666,8 +667,15 @@ class BrowseSkill extends React.Component {
         </div>
       );
     } else if (searchQuery.length > 0) {
-      renderSkillCount = (
-        <div style={{ padding: '10px' }}>
+      noSkillFound = (
+        <div
+          style={{
+            display: 'block',
+            margin: '0 auto',
+            padding: '10px',
+            width: isMobile ? '' : '50%',
+          }}
+        >
           <h2 style={{ fontWeight: '400' }}>
             Your search <b>&quot;{searchQuery}&quot;</b> did not match any
             skills.
@@ -680,8 +688,15 @@ class BrowseSkill extends React.Component {
         </div>
       );
     } else {
-      renderSkillCount = (
-        <div>
+      noSkillFound = (
+        <div
+          style={{
+            display: 'block',
+            margin: '0 auto',
+            textAlign: 'center',
+            width: isMobile ? '' : '50%',
+          }}
+        >
           No result found for <SidebarLink to="/">SUSI Skill</SidebarLink>
           :&nbsp;
           {routeValue && (
@@ -903,6 +918,7 @@ class BrowseSkill extends React.Component {
             <ContentContainer>
               {metricsHidden ? (
                 <div>
+                  {noSkillFound}
                   <Grid
                     container
                     spacing={3}

--- a/src/components/cms/BrowseSkill/BrowseSkill.js
+++ b/src/components/cms/BrowseSkill/BrowseSkill.js
@@ -65,6 +65,13 @@ const Link = styled(_Link)`
   }
 `;
 
+const NoSkillFound = styled.div`
+  display: block;
+  margin: 0 auto;
+  padding: 10px;
+  text-align: center;
+`;
+
 const SkillsFormControl = styled(FormControl)`
   width: 6.8rem;
   margin: 1rem 0.625rem 1rem 0;
@@ -669,14 +676,7 @@ class BrowseSkill extends React.Component {
       );
     } else if (searchQuery.length > 0) {
       noSkillFound = (
-        <div
-          style={{
-            display: 'block',
-            margin: '0 auto',
-            padding: '10px',
-            width: isMobile ? '' : '50%',
-          }}
-        >
+        <NoSkillFound>
           <h2 style={{ fontWeight: '400' }}>
             Your search <b>&quot;{searchQuery}&quot;</b> did not match any
             skills.
@@ -686,18 +686,11 @@ class BrowseSkill extends React.Component {
             <li>Using more general terms</li>
             <li>Checking your spelling</li>
           </ul>
-        </div>
+        </NoSkillFound>
       );
     } else {
       noSkillFound = (
-        <div
-          style={{
-            display: 'block',
-            margin: '0 auto',
-            textAlign: 'center',
-            width: isMobile ? '' : '50%',
-          }}
-        >
+        <NoSkillFound>
           No result found for <SidebarLink to="/">SUSI Skill</SidebarLink>
           :&nbsp;
           {routeValue && (
@@ -705,7 +698,7 @@ class BrowseSkill extends React.Component {
               {routeValue}
             </span>
           )}
-        </div>
+        </NoSkillFound>
       );
     }
 


### PR DESCRIPTION
Fixes #3003 

Changes: Earlier the no skills text was inside the grid which had defined columns so it wasn't possible to center align the the individual grid with respect to the screen. Have placed the text in a new division (instead of reusing that in grid) which shows up in case of no skills found.

Demo Link: https://pr-3020-fossasia-susi-web-chat.surge.sh

![Screenshot 2019-11-05 at 1 09 59 AM](https://user-images.githubusercontent.com/20151526/68239164-82234080-0030-11ea-9c5b-928cd8de3a37.png)
![Screenshot 2019-11-05 at 1 07 45 AM](https://user-images.githubusercontent.com/20151526/68239165-82bbd700-0030-11ea-8c9d-c314e68746e6.png)
![Screenshot 2019-11-06 at 1 05 12 AM](https://user-images.githubusercontent.com/20151526/68239731-869c2900-0031-11ea-96ca-24313df5dfb6.png)




