### PR TITLE
skill cards are now aligned vertically in mobile view

### DIFF
--- a/src/components/cms/SkillCardScrollList/SkillCard.js
+++ b/src/components/cms/SkillCardScrollList/SkillCard.js
@@ -25,9 +25,13 @@ const ScrollWrapper = styled.div`
   margin: 0.625rem;
   overflow-x: scroll;
   overflow-y: hidden;
-  white-space: nowrap;
   &::-webkit-scrollbar {
     display: none;
+  }
+  @media (max-width: 430px) {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
   }
 `;
 


### PR DESCRIPTION
Fixes #3034 

Changes: 
Cards are now aligned verically in mobile view.



Demo Link: https://pr-3036-fossasia-susi-web-chat.surge.sh

Screenshots of the change:
![issue](https://user-images.githubusercontent.com/53204850/68601175-d4011600-04c9-11ea-9d19-c2297bd761e9.png)

