### PR TITLE
fix for back button being hidden in skill version page #2949

### DIFF
--- a/src/components/cms/SkillVersion/SkillVersion.js
+++ b/src/components/cms/SkillVersion/SkillVersion.js
@@ -23,7 +23,9 @@ const Button = styled(_Button)`
   right: ${props => props.position + 'rem'};
   bottom: 2rem;
   position: fixed;
-  z-index: 1;
+  z-index: +1;
+  top: 70px;
+  height: 40px;
 `;
 
 const Container = styled.div`


### PR DESCRIPTION
previously back button was not being displayed correctly . Actually it was hidden under Susi chat bubble

Before change:
![Screenshot 2019-11-13 at 1 12 45 AM](https://user-images.githubusercontent.com/43617894/68705229-b27c5900-05b3-11ea-9a59-e040a63ec052.png)
After change:
![Screenshot 2019-11-13 at 1 12 47 AM](https://user-images.githubusercontent.com/43617894/68705166-937dc700-05b3-11ea-9776-4c1b3ed87d76.png)

Fixes #[Add issue number here. If you do not solve the issue entirely, please change the message e.g. "First steps for issue" #IssueNumber]

Changes: [Add here what changes were made in this pull request and if possible provide links showcasing the changes.]

Demo Link: https://pr-[ADD_PULL_REQUEST_NUMBER_HERE]-fossasia-susi-web-chat.surge.sh

Screenshots of the change: [Add screenshots depicting the changes.]

