### PR TITLE
fixed issue of back button being hidden under susi logo #2949

### DIFF
--- a/src/components/cms/SkillVersion/SkillVersion.js
+++ b/src/components/cms/SkillVersion/SkillVersion.js
@@ -23,7 +23,9 @@ const Button = styled(_Button)`
   right: ${props => props.position + 'rem'};
   bottom: 2rem;
   position: fixed;
-  z-index: 1;
+  z-index: +1;
+  top: 70px;
+  height: 40px;
 `;
 
 const Container = styled.div`


### PR DESCRIPTION
previously back button was not being displayed correctly . Actually it was hidden under Susi chat bubble

Before change:
![Screenshot 2019-11-13 at 1 12 45 AM](https://user-images.githubusercontent.com/43617894/68705229-b27c5900-05b3-11ea-9a59-e040a63ec052.png)
After change:
![Screenshot 2019-11-13 at 1 12 20 AM](https://user-images.githubusercontent.com/43617894/68705405-038c4d00-05b4-11ea-8425-6edd7fea4d84.png)

Fixes #2949