### PR TITLE
Added skills category as sidenav for mobile 

### DIFF
--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -10,6 +10,7 @@ import Select from '@material-ui/core/Select';
 import ISO6391 from 'iso-639-1';
 import AppBar from '@material-ui/core/AppBar';
 import IconButton from '@material-ui/core/IconButton';
+import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 import MenuItem from '@material-ui/core/MenuItem';
 import Translate from '../Translate/Translate.react';
 import styled, { css } from 'styled-components';
@@ -33,6 +34,7 @@ import CssBaseline from '@material-ui/core/CssBaseline';
 import Paper from '@material-ui/core/Paper';
 import Popper from './Popper';
 import _ExpandMore from '@material-ui/icons/ExpandMore';
+import MenuIcon from '@material-ui/icons/Menu';
 import ExpandingSearchField from '../ChatApp/SearchField.react';
 import ContactSupportIcon from '@material-ui/icons/ContactSupport';
 import Chat from '@material-ui/icons/Chat';
@@ -108,7 +110,28 @@ const TopRightMenuContainer = styled.div`
   margin-top: 1px;
 `;
 
+const SidebarTextStyles = css`
+  min-height: 1.5rem;
+  line-height: 1.5rem;
+  font-size: 0.875rem;
+  padding: 0 1.5rem;
+`;
+
+const SidebarItem = styled(MenuItem)`
+  ${SidebarTextStyles}
+`;
+
 const SusiLogoContainer = styled.div`
+  @media (max-width: 680px) {
+    ${props =>
+      props.isSearchOpen &&
+      css`
+        display: none;
+      `}
+  }
+`;
+
+const MenuButton = styled.div`
   @media (max-width: 680px) {
     ${props =>
       props.isSearchOpen &&
@@ -153,6 +176,7 @@ class NavigationBar extends Component {
     settings: PropTypes.object,
     location: PropTypes.object,
     isAdmin: PropTypes.bool,
+    groups: PropTypes.array,
     accessToken: PropTypes.string,
     email: PropTypes.string,
     userName: PropTypes.string,
@@ -185,6 +209,7 @@ class NavigationBar extends Component {
     super(props);
     this.state = {
       searchType: this.props.searchType,
+      left: false,
       searchSelectWidth: this.getSelectMenuWidth(this.props.searchType),
       showSearchBar: !isMobileView(1000),
       rightContainer: true,
@@ -236,10 +261,6 @@ class NavigationBar extends Component {
       this.props.history.push('/');
     }
   };
-
-  componentDidMount() {
-    this.loadLanguages('All');
-  }
 
   loadLanguages = value => {
     this.props.actions
@@ -355,6 +376,14 @@ class NavigationBar extends Component {
     }));
   };
 
+  toggleDrawer = open => event => {
+    if (event && event.type === 'keydown') {
+      return;
+    }
+
+    this.setState({ ...this.state, left: open });
+  };
+
   render() {
     const {
       accessToken,
@@ -375,7 +404,18 @@ class NavigationBar extends Component {
       searchType,
       languageValue,
     } = this.props;
-    const { searchSelectWidth, showSearchBar } = this.state;
+    let renderMenu = '';
+    renderMenu = this.props.groups.map(categoryName => {
+      const linkValue = '/category/' + categoryName;
+      return (
+        <Link to={linkValue} key={linkValue}>
+          <SidebarItem key={categoryName} value={categoryName}>
+            {categoryName}
+          </SidebarItem>
+        </Link>
+      );
+    });
+    const { searchSelectWidth, showSearchBar, left } = this.state;
     const Logged = props => (
       <React.Fragment>
         <Link to="/dashboard">
@@ -538,6 +578,24 @@ class NavigationBar extends Component {
           <AppBar>
             <Toolbar variant="dense">
               <FlexContainer>
+                {isMobileView() && (
+                  <MenuButton
+                    isSearchOpen={search}
+                    onClick={this.toggleDrawer(true)}
+                  >
+                    <MenuIcon style={{ margin: '2px 4px 2px 2px' }} />
+                  </MenuButton>
+                )}
+                {isMobileView() && (
+                  <SwipeableDrawer
+                    style={{ padding: '2px 2px 2px 2px' }}
+                    open={left}
+                    onClose={this.toggleDrawer(false)}
+                    onOpen={this.toggleDrawer(true)}
+                  >
+                    {renderMenu}
+                  </SwipeableDrawer>
+                )}
                 <SusiLogoContainer isSearchOpen={search}>
                   <Link to="/" style={{ outline: '0' }}>
                     {renderSusiIcon}

--- a/src/components/cms/BrowseSkill/BrowseSkill.js
+++ b/src/components/cms/BrowseSkill/BrowseSkill.js
@@ -26,7 +26,6 @@ import Devices from '@material-ui/icons/Devices';
 import Person from '@material-ui/icons/Person';
 import _ActionViewModule from '@material-ui/icons/ViewModule';
 import _ActionViewStream from '@material-ui/icons/ViewStream';
-import ChevronRight from '@material-ui/icons/ChevronRight';
 import Fab from '@material-ui/core/Fab';
 import NavigationArrowBack from '@material-ui/icons/ArrowBack';
 import NavigationArrowForward from '@material-ui/icons/ArrowForward';
@@ -150,29 +149,6 @@ const PageNavigationContainer = styled.div`
   margin: 0.5rem 0;
   @media (max-width: 418px) {
     justify-content: center;
-  }
-`;
-
-const MobileMenuItem = styled(MenuItem)`
-  min-height: 24px;
-  line-height: 24px;
-  font-size: 14px;
-`;
-
-const MobileMenuContainer = styled.div`
-  margin: 0 14px;
-  padding: 8px;
-  li {
-    border-top: 1px #e7e7e7 solid;
-    border-right: 1px #e7e7e7 solid;
-    border-left: 1px #e7e7e7 solid;
-  }
-  & a:last-child li {
-    border-bottom: 1px #e7e7e7 solid;
-    border-radius: 0 0 5px 5px;
-  }
-  & a:first-child li {
-    border-radius: 5px 5px 0 0;
   }
 `;
 
@@ -583,24 +559,12 @@ class BrowseSkill extends React.Component {
     let isMobile = isMobileView();
     let backToHome = null;
     let renderMenu = null;
-    let renderMobileMenu = null;
     if (isMobile) {
       backToHome = (
         <MobileBackButton variant="contained" color="default">
           <Link to="/">Back to SUSI Skills</Link>
         </MobileBackButton>
       );
-      renderMobileMenu = groups.map(categoryName => {
-        const linkValue = '/category/' + categoryName;
-        return (
-          <Link to={linkValue} key={linkValue}>
-            <MobileMenuItem key={categoryName} value={categoryName}>
-              <span style={{ width: '90%' }}>{categoryName}</span>
-              <ChevronRight style={{ top: -8 }} />
-            </MobileMenuItem>
-          </Link>
-        );
-      });
     }
     if (!isMobile) {
       renderMenu = groups.map(categoryName => {
@@ -1038,11 +1002,7 @@ class BrowseSkill extends React.Component {
               )}
               <div>{renderCardScrollList}</div>
               {/* Check if mobile view is currently active*/}
-              {routeType === 'category' ? (
-                backToHome
-              ) : (
-                <MobileMenuContainer>{renderMobileMenu}</MobileMenuContainer>
-              )}
+              {routeType === 'category' ? backToHome : null}
             </ContentContainer>
           )}
         </RightContainer>


### PR DESCRIPTION
Fixes #3002 

Changes: Now user won't have to scroll down for skills category in mobile view. It is included in the sidenav which appears when user clicks on the menu button which has been added to the left of Susi icon in the Navigation bar.
**Sidenav would be better UX**

**The sidenav will dissapear when user clicks elsewhere.**

Demo Link: https://pr-3050-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
![Screenshot 2019-11-13 at 8 22 32 PM](https://user-images.githubusercontent.com/20151526/68776251-caa4b480-0655-11ea-87f5-1f6b3882d495.png)
![Screenshot 2019-11-13 at 8 22 49 PM](https://user-images.githubusercontent.com/20151526/68776252-caa4b480-0655-11ea-99ee-f4fd4f07e1f9.png)



