### PR TITLE
Set warning messages separately for category,language and Skill name

### DIFF
--- a/src/components/cms/SkillCreator/SkillWizard.js
+++ b/src/components/cms/SkillCreator/SkillWizard.js
@@ -679,6 +679,36 @@ class SkillWizard extends Component {
     });
   };
 
+  getSnackbarMessage = (language, category, name) => {
+    let fields = [];
+    let message = 'Please do not leave the ';
+    if (language === '') {
+      fields.push('language');
+    }
+    if (category === null) {
+      fields.push('category');
+    }
+    if (name === '') {
+      fields.push('name');
+    }
+    let length = fields.length;
+    fields.map((field, index) => {
+      if (index === length - 2) {
+        message += field + ' and ';
+      } else if (index === length - 1) {
+        message += field;
+      } else {
+        message += field + ' , ';
+      }
+      return field;
+    });
+    if (length > 1) {
+      message += ' fields empty';
+    } else {
+      message += ' field empty';
+    }
+    return message;
+  };
   // eslint-disable-next-line complexity
   saveClick = async () => {
     const {
@@ -717,14 +747,17 @@ class SkillWizard extends Component {
       });
       return 0;
     }
-    if (category === null || language === '' || name === '') {
+
+    if (language === '' || category === null || name === '') {
+      let message = this.getSnackbarMessage(language, category, name);
       this.props.actions.openSnackBar({
-        snackBarMessage: 'Please select a group, language and a skill',
+        snackBarMessage: message,
         snackBarPosition: { vertical: 'top', horizontal: 'right' },
         variant: 'warning',
       });
       return 0;
     }
+
     if (
       !new RegExp(/.+\.\w+/g).test(imageUrl) &&
       !(


### PR DESCRIPTION
Fixes #3067 

Changes: 
Instead of hardcoding the warning message when no `category`,`language` or `skill name` is provided changes are done such that it displays warning messages accordingly.
 
Demo Link: https://pr-3068-fossasia-susi-web-chat.surge.sh

Screenshots of the change:
 
![vvdv](https://user-images.githubusercontent.com/45489945/68997191-a18c5a00-08c9-11ea-945e-5a1f72d59ee0.png)
