### PR TITLE
feat(): added content loader for cards

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "react-chartkick": "0.3.1",
     "react-color": "2.17.3",
     "react-container-dimensions": "1.4.1",
+    "react-content-loader": "^4.3.2",
     "react-cookie": "4.0.0",
     "react-copy-to-clipboard": "5.0.1",
     "react-custom-scrollbars": "4.2.1",

--- a/src/components/cms/BrowseSkill/BrowseSkill.js
+++ b/src/components/cms/BrowseSkill/BrowseSkill.js
@@ -4,6 +4,7 @@ import { Link as _Link } from 'react-router-dom';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 import styled, { css } from 'styled-components';
+import SkillLoader from './skillLoader';
 import skillActions from '../../../redux/actions/skills';
 import uiActions from '../../../redux/actions/ui';
 import FormControl from '@material-ui/core/FormControl';
@@ -36,7 +37,6 @@ import IconButton from '@material-ui/core/IconButton';
 import ClickAwayListener from '@material-ui/core/ClickAwayListener';
 import Grow from '@material-ui/core/Grow';
 import Popper from '@material-ui/core/Popper';
-import CircularLoader from '../../shared/CircularLoader';
 import SkillCardList from '../SkillCardList/SkillCardList';
 import SkillCardGrid from '../SkillCardGrid/SkillCardGrid';
 import SkillCardScrollList from '../SkillCardScrollList/SkillCardScrollList';
@@ -907,7 +907,7 @@ class BrowseSkill extends React.Component {
         <RightContainer>
           {renderSkillSlideshow}
           {loadingSkills ? (
-            <CircularLoader height={34} />
+            <SkillLoader />
           ) : (
             <ContentContainer>
               {metricsHidden ? (

--- a/src/components/cms/BrowseSkill/skillLoader.js
+++ b/src/components/cms/BrowseSkill/skillLoader.js
@@ -18,12 +18,11 @@ const addLoader = () => {
   const limit = isMobileView() ? 2 : 4;
   for (let i = 0; i < limit; i++) {
     loader.push(
-      <ContentLoader>
+      <ContentLoader speed={2}>
         <circle cx="34" cy="34" r="34" />
         <rect x="75" y="18" rx="4" ry="4" width="140" height="30" />
-        <rect x="0" y="100" rx="5" ry="5" width="80" height="14" />
-        <rect x="0" y="120" rx="5" ry="5" width="140" height="12" />
-        <rect x="150" y="120" rx="5" ry="5" width="40" height="12" />
+        <rect x="0" y="100" rx="8" ry="8" width="150" height="12" />
+        <rect x="0" y="120" rx="8" ry="8" width="90" height="12" />
       </ContentLoader>,
     );
   }

--- a/src/components/cms/BrowseSkill/skillLoader.js
+++ b/src/components/cms/BrowseSkill/skillLoader.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Facebook } from 'react-content-loader';
+import _ContentLoader from 'react-content-loader';
 import styled from 'styled-components';
 import isMobileView from '../../../utils/isMobileView';
 
@@ -7,8 +7,8 @@ const Container = styled.div`
   display: flex;
 `;
 
-const Loader = styled(Facebook)`
-  width: 260px;
+const ContentLoader = styled(_ContentLoader)`
+  width: 280px;
   height: 168px;
   margin: 20px;
 `;
@@ -17,7 +17,15 @@ const addLoader = () => {
   const loader = [];
   const limit = isMobileView() ? 2 : 4;
   for (let i = 0; i < limit; i++) {
-    loader.push(<Loader />);
+    loader.push(
+      <ContentLoader>
+        <circle cx="34" cy="34" r="34" />
+        <rect x="75" y="18" rx="4" ry="4" width="140" height="30" />
+        <rect x="0" y="100" rx="5" ry="5" width="80" height="14" />
+        <rect x="0" y="120" rx="5" ry="5" width="140" height="12" />
+        <rect x="150" y="120" rx="5" ry="5" width="40" height="12" />
+      </ContentLoader>,
+    );
   }
   return loader;
 };

--- a/src/components/cms/BrowseSkill/skillLoader.js
+++ b/src/components/cms/BrowseSkill/skillLoader.js
@@ -8,7 +8,7 @@ const Container = styled.div`
 `;
 
 const ContentLoader = styled(_ContentLoader)`
-  width: 280px;
+  width: 260px;
   height: 168px;
   margin: 20px;
 `;
@@ -19,10 +19,10 @@ const addLoader = () => {
   for (let i = 0; i < limit; i++) {
     loader.push(
       <ContentLoader speed={2}>
-        <circle cx="34" cy="34" r="34" />
-        <rect x="75" y="18" rx="4" ry="4" width="140" height="30" />
-        <rect x="0" y="100" rx="8" ry="8" width="150" height="12" />
-        <rect x="0" y="120" rx="8" ry="8" width="90" height="12" />
+        <circle cx="28" cy="28" r="28" />
+        <rect x="75" y="14" rx="4" ry="4" width="140" height="30" />
+        <rect x="0" y="80" rx="8" ry="8" width="200" height="8" />
+        <rect x="0" y="100" rx="8" ry="8" width="120" height="8" />
       </ContentLoader>,
     );
   }

--- a/src/components/cms/BrowseSkill/skillLoader.js
+++ b/src/components/cms/BrowseSkill/skillLoader.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import _ContentLoader from 'react-content-loader';
+import ContentLoader from 'react-content-loader';
 import styled from 'styled-components';
 import isMobileView from '../../../utils/isMobileView';
 
@@ -7,10 +7,11 @@ const Container = styled.div`
   display: flex;
 `;
 
-const ContentLoader = styled(_ContentLoader)`
+const ContentContainer = styled.div`
   width: 260px;
   height: 168px;
-  margin: 20px;
+  margin: 8px;
+  border: 0.5px solid #eaeded;
 `;
 
 const addLoader = () => {
@@ -18,12 +19,14 @@ const addLoader = () => {
   const limit = isMobileView() ? 2 : 4;
   for (let i = 0; i < limit; i++) {
     loader.push(
-      <ContentLoader speed={2}>
-        <circle cx="28" cy="28" r="28" />
-        <rect x="75" y="14" rx="4" ry="4" width="140" height="30" />
-        <rect x="0" y="80" rx="8" ry="8" width="200" height="8" />
-        <rect x="0" y="100" rx="8" ry="8" width="120" height="8" />
-      </ContentLoader>,
+      <ContentContainer>
+        <ContentLoader width={260} height={168} speed={2}>
+          <circle cx="44" cy="46" r="28" />
+          <rect x="100" y="24" rx="4" ry="4" width="120" height="44" />
+          <rect x="10" y="120" rx="8" ry="8" width="180" height="10" />
+          <rect x="10" y="140" rx="8" ry="8" width="120" height="10" />
+        </ContentLoader>
+      </ContentContainer>,
     );
   }
   return loader;

--- a/src/components/cms/BrowseSkill/skillLoader.js
+++ b/src/components/cms/BrowseSkill/skillLoader.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { Facebook } from 'react-content-loader';
+import styled from 'styled-components';
+import isMobileView from '../../../utils/isMobileView';
+
+const Container = styled.div`
+  display: flex;
+`;
+
+const Loader = styled(Facebook)`
+  width: 260px;
+  height: 168px;
+  margin: 20px;
+`;
+
+const addLoader = () => {
+  const loader = [];
+  const limit = isMobileView() ? 2 : 4;
+  for (let i = 0; i < limit; i++) {
+    loader.push(<Loader />);
+  }
+  return loader;
+};
+
+const SkillLoader = () => {
+  return (
+    <div>
+      <Container>{addLoader()}</Container>
+      <Container>{addLoader()}</Container>
+      <Container>{addLoader()}</Container>
+    </div>
+  );
+};
+
+export default SkillLoader;


### PR DESCRIPTION
Fixes #3063 

Changes:  Have added react content loader. Instead of traditional spinner the content loader shows up just like in Facebook, youtube etc. From UI perspective content loaders look better when there are cards present on the page

Demo Link: https://pr-3090-fossasia-susi-web-chat.surge.sh

![Screenshot 2019-12-24 at 9 32 58 PM](https://user-images.githubusercontent.com/20151526/71422313-e9f81e00-26a6-11ea-83e1-8c6ce1521534.png)




