### PR TITLE
Fixes: #3079 Now the icons on the chat window have titles

### DIFF
--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -25,6 +25,7 @@ import _Close from '@material-ui/icons/Close';
 import _FullScreen from '@material-ui/icons/Fullscreen';
 import _FullScreenExit from '@material-ui/icons/FullscreenExit';
 import { IconButton as _IconButton } from '@material-ui/core';
+import ToolTip from '../../shared/ToolTip';
 
 const MessageList = styled.div`
   background: ${props => props.pane};
@@ -758,15 +759,21 @@ class MessageSection extends Component {
           )}
           <CustomIconButton width={width}>
             {mode === 'fullScreen' ? (
-              <FullScreenExit onClick={this.openPreview} />
+              <ToolTip title="Exit full screen">
+                <FullScreenExit onClick={this.openPreview} />
+              </ToolTip>
             ) : (
-              <FullScreen onClick={this.openFullScreen} />
+              <ToolTip title="Full screen">
+                <FullScreen onClick={this.openFullScreen} />
+              </ToolTip>
             )}
           </CustomIconButton>
           <IconButton
             onClick={mode === 'fullScreen' ? this.handleClose : this.toggleChat}
           >
-            <Close />
+            <ToolTip title="Close">
+              <Close />
+            </ToolTip>
           </IconButton>
         </div>
       </ActionBar>

--- a/src/components/ChatApp/SearchField.react.js
+++ b/src/components/ChatApp/SearchField.react.js
@@ -6,6 +6,7 @@ import SearchIcon from '@material-ui/icons/Search';
 import _CloseIcon from '@material-ui/icons/Close';
 import _UpIcon from '@material-ui/icons/ExpandLess';
 import _DownIcon from '@material-ui/icons/ExpandMore';
+import ToolTip from '../shared/ToolTip';
 
 const ESCAPE_KEY = 27;
 const F_KEY = 70;
@@ -195,7 +196,9 @@ class ExpandingSearchField extends Component {
       <React.Fragment>
         <Container>
           <IconButton onClick={this.onClick}>
-            <SearchIcon />
+            <ToolTip title="Search">
+              <SearchIcon />
+            </ToolTip>
           </IconButton>
         </Container>
         {open && (


### PR DESCRIPTION
Fixes #3079 

Changes: The icons on the chat window now have titles like 'search', 'Full screen','Exit' and when in full screen it shows 'Exit full screen' for full screen option

Demo Link: https://pr-3092-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
![Screenshot (1)](https://user-images.githubusercontent.com/47773353/69375374-2ca49000-0cce-11ea-855c-c8c5ad8da793.png)
![Screenshot (2)](https://user-images.githubusercontent.com/47773353/69375384-3201da80-0cce-11ea-9f4f-60d3a5be2084.png)
![Screenshot (3)](https://user-images.githubusercontent.com/47773353/69375388-34fccb00-0cce-11ea-813f-0c4ab0ec213e.png)
![Screenshot (4)](https://user-images.githubusercontent.com/47773353/69375394-38905200-0cce-11ea-8d35-8c29633856cf.png)
