### PR TITLE
Fixes #3107 - Buttons are now placed at right positions for mobile devices too

### DIFF
--- a/src/components/ChatApp/ChatApp.css
+++ b/src/components/ChatApp/ChatApp.css
@@ -50,4 +50,5 @@
 
 .chatbubble {
   z-index:100;
+  top:88.5%;
 }

--- a/src/components/shared/ScrollTopButton.js
+++ b/src/components/shared/ScrollTopButton.js
@@ -7,7 +7,7 @@ import Fade from '@material-ui/core/Fade';
 
 const ScrollTopFab = styled(Fab)`
   position: fixed;
-  top: ${props => props.height - 95 + 'px'};
+  top: ${props => '89%'};
   right: ${props => (props.width < 1100 ? '70px' : '100px')};
   margin: 15px;
 `;


### PR DESCRIPTION
Fixes  #3107

Changes: Now percentages are used as the device height may vary and different heights are supposed to be allocated

Demo Link: https://pr-3108-fossasia-susi-web-chat.surge.sh


