### PR TITLE
fix(skillCard): added property to truncate text in card

### DIFF
--- a/src/components/cms/SkillCardGrid/SkillCardGrid.js
+++ b/src/components/cms/SkillCardGrid/SkillCardGrid.js
@@ -28,6 +28,13 @@ const Author = styled.div`
   color: #555555;
 `;
 
+const TruncatedName = styled.p`
+  white-space: nowrap;
+  width: 80%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+`;
+
 const GridList = styled.div`
   flex-wrap: wrap;
   flex-direction: row;
@@ -120,7 +127,7 @@ class SkillCardGrid extends Component {
             {staffPick && <StaffPickImage />}
           </TitleContainer>
           <Author>
-            <p>{authorName}</p>
+            <TruncatedName>{authorName}</TruncatedName>
           </Author>
           <div style={{ positive: 'relative', float: 'left' }}>
             <div data-tip="custom" data-for={dataId}>


### PR DESCRIPTION
Fixes #3117 

Changes: Added CSS properties to truncate long author names

Demo Link: https://pr-3118-fossasia-susi-web-chat.surge.sh

Screenshots of the change:
![Screenshot 2019-12-18 at 1 09 32 AM](https://user-images.githubusercontent.com/20151526/71028557-83698200-2133-11ea-8299-c684253d8cd6.png)


