### PR TITLE
Fixes #3123 Now Skill Names are correctly displayed

### DIFF
--- a/src/components/cms/SkillRating/SkillRatingCard.js
+++ b/src/components/cms/SkillRating/SkillRatingCard.js
@@ -28,6 +28,7 @@ import {
   LargeText,
 } from '../../shared/Typography';
 import LineChart from '../../shared/charts/LineChart';
+import getSkillNameFromSkillTag from '../../../utils/getSkillNameFromSkillTag';
 
 const Paper = styled(_Paper)`
   width: 100%;
@@ -198,7 +199,10 @@ class SkillRatingCard extends Component {
             <div>
               <SubTitle size="1rem">
                 {' '}
-                Rate your experience with {skillTag} on SUSI.AI{' '}
+                Rate your experience with {getSkillNameFromSkillTag(
+                  skillTag,
+                )}{' '}
+                on SUSI.AI{' '}
               </SubTitle>
               <div
                 style={{

--- a/src/utils/getSkillNameFromSkillTag.js
+++ b/src/utils/getSkillNameFromSkillTag.js
@@ -1,0 +1,9 @@
+const getSkillNameFromSkillTag = skillTag => {
+  var name = skillTag.replace(/_/g, ' ');
+  var regularExpression = /(\b[a-z](?!\s))/g;
+  name = name.replace(regularExpression, function(x) {
+    return x.toUpperCase();
+  });
+  return name;
+};
+export default getSkillNameFromSkillTag;


### PR DESCRIPTION
Fixes #3123

Changes: 
Created a new function to implement correct rendering of name to be diplayed

Demo Link: https://pr-3131-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 

![Screenshot 2019-12-20 at 4 46 20 PM](https://user-images.githubusercontent.com/43617894/71251385-42968680-2348-11ea-89c1-0a69397da58c.png)
