### PR TITLE
Made changes in Preview to view previous chat message

### DIFF
--- a/src/components/ChatApp/MessageComposer.react.js
+++ b/src/components/ChatApp/MessageComposer.react.js
@@ -17,10 +17,9 @@ import uiActions from '../../redux/actions/ui';
 import { invertColorTextArea } from '../../utils/invertColor';
 import getCustomThemeColors from '../../utils/colors';
 import VoiceRecognition from './VoiceRecognition';
+import onChatComposerKeyDown from '../../utils/onChatComposerKeyDown';
 
 const ENTER_KEY_CODE = 13;
-const UP_KEY_CODE = 38;
-const DOWN_KEY_CODE = 40;
 
 const SendButton = styled(IconButton)`
   align-content: center;
@@ -359,36 +358,17 @@ class MessageComposer extends Component {
         this.setState({ text: '', currentMessageIndex: -1 });
       }
     } else {
-      switch (event.keyCode) {
-        case UP_KEY_CODE: {
-          event.preventDefault();
-          const newMessageIndex =
-            (currentMessageIndex + 1) % this.userMessageHistory.length;
-          this.setState({
-            text: this.userMessageHistory[newMessageIndex],
-            currentMessageIndex: newMessageIndex,
-          });
-          break;
-        }
-        case DOWN_KEY_CODE: {
-          event.preventDefault();
-          if (currentMessageIndex - 1 === -1) {
-            const newMessageIndex = this.userMessageHistory.length - 1;
-            this.setState({
-              text: this.userMessageHistory[newMessageIndex],
-              currentMessageIndex: newMessageIndex,
-            });
-          } else {
-            const newMessageIndex = currentMessageIndex - 1;
-            this.setState({
-              text: this.userMessageHistory[newMessageIndex],
-              currentMessageIndex: newMessageIndex,
-            });
-          }
-          break;
-        }
-        default:
-          break;
+      const { message, newMessageIndex } = onChatComposerKeyDown(
+        event.keyCode,
+        this.userMessageHistory,
+        currentMessageIndex,
+      );
+      if (message !== '') {
+        event.preventDefault();
+        this.setState({
+          text: message,
+          currentMessageIndex: newMessageIndex,
+        });
       }
     }
   };

--- a/src/components/cms/BotBuilder/Preview/Preview.js
+++ b/src/components/cms/BotBuilder/Preview/Preview.js
@@ -11,6 +11,9 @@ import _ChevronRight from '@material-ui/icons/ChevronRight';
 import loadingGIF from '../../../../images/loading.gif';
 import MessageBubble from '../../../ChatApp/MessageListItem/MessageBubbleStyle';
 import './Chatbot.css';
+import onChatComposerKeyDown from '../../../../utils/onChatComposerKeyDown';
+
+const ENTER_KEY_CODE = 13;
 
 const Paper = styled(_Paper)`
   width: ${props => props.width};
@@ -82,7 +85,6 @@ const SUSIFrameContainer = styled.div`
     props.width > 1200 ? props.height - 250 + 'px' : '630px'};
   width: 100%;
   animation: ${moveFromBottomFadeKeyframe} 0.3s ease both;
-
   media(max-width: 667px) {
     left: 0;
     right: 0;
@@ -193,7 +195,6 @@ const SUSICommentContent = styled.div`
 const H1 = styled.h1`
   margin: 0px;
   text-align: center;
-
   @media (max-width: 769px) {
     padding-top: 0rem;
   }
@@ -245,6 +246,9 @@ class Preview extends Component {
       previewChat: true,
       width: window.innerWidth,
       height: window.innerHeight,
+      messageHistory: [],
+      showMessage: false,
+      currentMessageIndex: -1,
     };
   }
 
@@ -260,9 +264,14 @@ class Preview extends Component {
   };
 
   sendMessage = async event => {
-    const { message } = this.state;
+    const { message, messageHistory } = this.state;
     const { code } = this.props;
     if (message.trim().length > 0) {
+      this.setState({
+        messageHistory: [message, ...messageHistory],
+        showMessage: true,
+        currentMessageIndex: -1,
+      });
       this.addMessage(message, 'You');
       const encodedMessage = encodeURIComponent(message);
       const encodedCode = encodeURIComponent(code);
@@ -305,6 +314,27 @@ class Preview extends Component {
         console.log('Could not fetch reply');
       }
       this.setState({ message: '' });
+    }
+  };
+
+  onKeydown = event => {
+    if (event.keyCode === ENTER_KEY_CODE) {
+      event.preventDefault();
+      this.sendMessage();
+    } else {
+      const { messageHistory, currentMessageIndex } = this.state;
+      const { message, newMessageIndex } = onChatComposerKeyDown(
+        event.keyCode,
+        messageHistory,
+        currentMessageIndex,
+      );
+      if (message !== '') {
+        event.preventDefault();
+        this.setState({
+          message: message,
+          currentMessageIndex: newMessageIndex,
+        });
+      }
     }
   };
 
@@ -461,7 +491,7 @@ class Preview extends Component {
                                     rows="1"
                                     value={message}
                                     onKeyPress={event => {
-                                      if (event.which === 13) {
+                                      if (event.which === ENTER_KEY_CODE) {
                                         event.preventDefault();
                                       }
                                     }}
@@ -471,9 +501,7 @@ class Preview extends Component {
                                       })
                                     }
                                     onKeyDown={event => {
-                                      if (event.keyCode === 13) {
-                                        this.sendMessage();
-                                      }
+                                      this.onKeydown(event);
                                     }}
                                   />
                                   <div>

--- a/src/utils/onChatComposerKeyDown.js
+++ b/src/utils/onChatComposerKeyDown.js
@@ -1,0 +1,35 @@
+const UP_KEY_CODE = 38;
+const DOWN_KEY_CODE = 40;
+
+const onChatComposerKeyDown = (keyCode, messageHistory, currentIndex) => {
+  switch (keyCode) {
+    case UP_KEY_CODE: {
+      const newMessageIndex = (currentIndex + 1) % messageHistory.length;
+      return {
+        message: messageHistory[newMessageIndex],
+        newMessageIndex: newMessageIndex,
+      };
+    }
+    case DOWN_KEY_CODE: {
+      if (currentIndex - 1 === -1) {
+        const newMessageIndex = messageHistory.length - 1;
+        return {
+          message: messageHistory[newMessageIndex],
+          newMessageIndex: newMessageIndex,
+        };
+      }
+      const newMessageIndex = currentIndex - 1;
+      return {
+        message: messageHistory[newMessageIndex],
+        newMessageIndex: newMessageIndex,
+      };
+    }
+    default:
+      return {
+        message: '',
+        newMessageIndex: -1,
+      };
+  }
+};
+
+export default onChatComposerKeyDown;


### PR DESCRIPTION
Fixes #3145 

Changes: 
- View the previous message in the chat by calling function `bringPreviousMessage()`.
- When `UP_KEY_CODE` or `DOWN_KEY_CODE` is the `keyCode` user entered it will call the conditions accordingly.

Demo Link: https://pr-3146-fossasia-susi-web-chat.surge.sh

Screenshots of the change:

![final_5e044f0ca4326f0014dfb517_421762](https://user-images.githubusercontent.com/45489945/71461278-4bb6a600-27d5-11ea-8cae-109673f0286f.gif)

