### PR TITLE
Fix alignment issue in team page

### DIFF
--- a/src/components/About/Team/index.js
+++ b/src/components/About/Team/index.js
@@ -73,6 +73,8 @@ const TeamContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
   padding: 0rem;
+  margin-left: auto;
+  margin-right: auto;
 `;
 
 const Heading = styled.div`
@@ -80,7 +82,8 @@ const Heading = styled.div`
   font: 300 2.125rem/2.5rem sans-serif;
   letter-spacing: -0.01em;
   margin: 2.5rem 0 1.25rem;
-  text-align: left;
+  text-align: center;
+  width: 100%;
 
   @media (max-width: 1000px) {
     font-size: 2.25rem;


### PR DESCRIPTION
# Purpose 
The purpose of this PR is to fix issue #3151 

# Approach
- Update CSS rules of const TeamContianer and const Heading

# Preview
http://142.93.213.121/

# Screenshot

- Before 
<img width="1676" alt="Screenshot 2019-12-26 at 22 51 23" src="https://user-images.githubusercontent.com/27630091/71484458-86026080-2832-11ea-9315-7a3ce0f99cb9.png">

- After

<img width="1680" alt="Screenshot 2019-12-26 at 22 52 04" src="https://user-images.githubusercontent.com/27630091/71484474-9a465d80-2832-11ea-803b-5db2cd092260.png">
