### PR TITLE
Added back to top button in SUSI AI Contact Page

### DIFF
--- a/src/components/About/Contact/Contact.react.js
+++ b/src/components/About/Contact/Contact.react.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Header } from '../../shared/About';
+import ScrollTopButton from '../../shared/ScrollTopButton';
 import { scrollToTopAnimation } from '../../../utils/animateScroll';
 import styled, { css } from 'styled-components';
 
@@ -89,8 +90,9 @@ const Contact = props => {
           to report the issue
         </ContactContent>
       </Section>
-    </div>
-  );
+    <ScrollTopButton />
+   </div>
+ );
 };
 
 Contact.propTypes = {


### PR DESCRIPTION
Fixes #3185 

Changes: As mentioned in issue #3185 the SUSI AI Contact Page lacked a back to top button hence to improve functionality I have added the scroll button the page.

Demo Link: https://pr-3191-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
![Screenshot (242)](https://user-images.githubusercontent.com/58459496/71683506-c759b980-2db8-11ea-9f78-e53e91ec2d2e.png)
![Screenshot (243)](https://user-images.githubusercontent.com/58459496/71683513-c9237d00-2db8-11ea-92a0-8fa90db2df0c.png)
![Screenshot (244)](https://user-images.githubusercontent.com/58459496/71683521-cc1e6d80-2db8-11ea-9a83-080b54302301.png)

