### PR TITLE
Added back to top button in SUSI AI Contact Page

### DIFF
--- a/src/components/About/Contact/Contact.react.js
+++ b/src/components/About/Contact/Contact.react.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Header } from '../../shared/About';
+import ScrollTopButton from '../../shared/ScrollTopButton';
 import { scrollToTopAnimation } from '../../../utils/animateScroll';
 import styled, { css } from 'styled-components';
 
@@ -89,8 +90,9 @@ const Contact = props => {
           to report the issue
         </ContactContent>
       </Section>
-    </div>
-  );
+    <ScrollTopButton />
+   </div>
+ );
 };
 
 Contact.propTypes = {

--- a/src/components/About/Contact/Contact.react.js
+++ b/src/components/About/Contact/Contact.react.js
@@ -90,10 +90,10 @@ const Contact = props => {
           to report the issue
         </ContactContent>
       </Section>
-    <ScrollTopButton />
-   </div>
- );
-};
+      <ScrollTopButton />
+     </div>
+    );
+   };
 
 Contact.propTypes = {
   history: PropTypes.object,


### PR DESCRIPTION
Fixes #3185 
Changes: As mentioned in issue #3185 there was a lack of a back to top button. Seeing its presend=ce on every other page on SUSI AI website as well as to improve functionality of website I have added it to the contacts page as well.

Demo Link: https://pr-3192-fossasia-susi-web-chat.surge.sh

Screenshots of the change:
![Screenshot (242)](https://user-images.githubusercontent.com/58459496/71684132-9da19200-2dba-11ea-879a-c7e846968053.png)
![Screenshot (243)](https://user-images.githubusercontent.com/58459496/71684139-9f6b5580-2dba-11ea-8cb3-e02e0cecc002.png)
![Screenshot (244)](https://user-images.githubusercontent.com/58459496/71684145-a1cdaf80-2dba-11ea-8ae9-1b02fcea929a.png)




