### PR TITLE
Show table in Analytics only when content is available

### DIFF
--- a/src/components/cms/Dashboard/MyAnalytics.js
+++ b/src/components/cms/Dashboard/MyAnalytics.js
@@ -79,7 +79,7 @@ class MyAnalytics extends Component {
           <CircularLoader height={5} />
         ) : (
           <Container>
-            {skillUsageCount !== 0 && (
+            {skillUsage && Array.isArray(skillUsage) && skillUsageCount !== 0 && (
               <React.Fragment>
                 <SubTitle marginLeft={1.4}>Skill Usage Distribution</SubTitle>
                 <PieChartContainer

--- a/src/components/cms/Dashboard/MyRatings.js
+++ b/src/components/cms/Dashboard/MyRatings.js
@@ -77,76 +77,80 @@ class MyRatings extends Component {
           <TableSleleton />
         ) : (
           <TableWrap>
-            <MaterialTable
-              title="My Rating"
-              columns={[
-                {
-                  title: 'Skill Name',
-                  field: 'skillName',
-                  render: rowData => {
-                    return (
-                      <Link
-                        to={{
-                          pathname: `/${rowData.group}/${getSkillFromRating(
-                            rowData.skillName,
-                          )}/${rowData.language}`,
-                        }}
-                      >
-                        {(
-                          rowData.skillName.charAt(0).toUpperCase() +
-                          rowData.skillName.slice(1)
-                        ).replace(/[_-]/g, ' ')}
-                      </Link>
-                    );
-                  },
-                },
-                {
-                  title: 'Rating',
-                  field: 'rating',
-                  render: rowData => {
-                    return (
-                      <Ratings
-                        rating={rowData.skillStar}
-                        widgetRatedColors="#ffbb28"
-                        widgetDimensions="20px"
-                        widgetSpacings="0px"
-                      >
-                        <Ratings.Widget />
-                        <Ratings.Widget />
-                        <Ratings.Widget />
-                        <Ratings.Widget />
-                        <Ratings.Widget />
-                      </Ratings>
-                    );
-                  },
-                },
-                {
-                  title: 'Timestamp',
-                  field: 'timestamp',
-                  render: rowData => {
-                    return parseDate(rowData.ratingTimestamp);
-                  },
-                },
-              ]}
-              data={ratingsData.map((rating, index) => {
-                return {
-                  group: rating.group,
-                  skillName: rating.skillName,
-                  ratingTimestamp: rating.ratingTimestamp,
-                  skillStar: rating.skillStar,
-                  language: rating.language,
-                };
-              })}
-              options={{
-                search: false,
-                toolbar: false,
-                headerStyle: {
-                  backgroundColor: '#6fa2ff',
-                  color: '#FFF',
-                  fontSize: '1.2rem',
-                },
-              }}
-            />
+            {ratingsData &&
+              Array.isArray(ratingsData) &&
+              ratingsData.length !== 0 && (
+                <MaterialTable
+                  title="My Rating"
+                  columns={[
+                    {
+                      title: 'Skill Name',
+                      field: 'skillName',
+                      render: rowData => {
+                        return (
+                          <Link
+                            to={{
+                              pathname: `/${rowData.group}/${getSkillFromRating(
+                                rowData.skillName,
+                              )}/${rowData.language}`,
+                            }}
+                          >
+                            {(
+                              rowData.skillName.charAt(0).toUpperCase() +
+                              rowData.skillName.slice(1)
+                            ).replace(/[_-]/g, ' ')}
+                          </Link>
+                        );
+                      },
+                    },
+                    {
+                      title: 'Rating',
+                      field: 'rating',
+                      render: rowData => {
+                        return (
+                          <Ratings
+                            rating={rowData.skillStar}
+                            widgetRatedColors="#ffbb28"
+                            widgetDimensions="20px"
+                            widgetSpacings="0px"
+                          >
+                            <Ratings.Widget />
+                            <Ratings.Widget />
+                            <Ratings.Widget />
+                            <Ratings.Widget />
+                            <Ratings.Widget />
+                          </Ratings>
+                        );
+                      },
+                    },
+                    {
+                      title: 'Timestamp',
+                      field: 'timestamp',
+                      render: rowData => {
+                        return parseDate(rowData.ratingTimestamp);
+                      },
+                    },
+                  ]}
+                  data={ratingsData.map((rating, index) => {
+                    return {
+                      group: rating.group,
+                      skillName: rating.skillName,
+                      ratingTimestamp: rating.ratingTimestamp,
+                      skillStar: rating.skillStar,
+                      language: rating.language,
+                    };
+                  })}
+                  options={{
+                    search: false,
+                    toolbar: false,
+                    headerStyle: {
+                      backgroundColor: '#6fa2ff',
+                      color: '#FFF',
+                      fontSize: '1.2rem',
+                    },
+                  }}
+                />
+              )}
           </TableWrap>
         )}
         {ratingsData.length === 0 && !loading && (

--- a/src/components/cms/Dashboard/MySkills.js
+++ b/src/components/cms/Dashboard/MySkills.js
@@ -102,99 +102,104 @@ class MySkills extends Component {
           <TableSleleton />
         ) : (
           <TableWrap>
-            {userSkills.length !== 0 && (
-              <MaterialTable
-                title="My Skills"
-                columns={[
-                  {
-                    title: 'Image',
-                    field: 'imageLink',
-                    render: rowData => {
-                      return (
-                        <Link
-                          to={{
-                            pathname: `/${
-                              rowData.group
-                            }/${rowData.skillTag
-                              .toLowerCase()
-                              .replace(/ /g, '_')}/${rowData.language}`,
-                          }}
-                        >
-                          <Img
-                            // eslint-disable-next-line
-                            src={getImageSrc({
-                              relativePath: `model=general&language=${
-                                rowData.language
-                              }&group=${rowData.group.replace(
-                                / /g,
-                                '%20',
-                              )}&image=/${rowData.image}`,
-                            })}
-                            unloader={
-                              <CircleImage name={rowData.skillName} size="40" />
-                            }
-                          />
-                        </Link>
-                      );
+            {userSkills &&
+              Array.isArray(userSkills) &&
+              userSkills.length !== 0 && (
+                <MaterialTable
+                  title="My Skills"
+                  columns={[
+                    {
+                      title: 'Image',
+                      field: 'imageLink',
+                      render: rowData => {
+                        return (
+                          <Link
+                            to={{
+                              pathname: `/${
+                                rowData.group
+                              }/${rowData.skillTag
+                                .toLowerCase()
+                                .replace(/ /g, '_')}/${rowData.language}`,
+                            }}
+                          >
+                            <Img
+                              // eslint-disable-next-line
+                              src={getImageSrc({
+                                relativePath: `model=general&language=${
+                                  rowData.language
+                                }&group=${rowData.group.replace(
+                                  / /g,
+                                  '%20',
+                                )}&image=/${rowData.image}`,
+                              })}
+                              unloader={
+                                <CircleImage
+                                  name={rowData.skillName}
+                                  size="40"
+                                />
+                              }
+                            />
+                          </Link>
+                        );
+                      },
                     },
-                  },
-                  {
-                    title: 'Name',
-                    field: 'name',
-                    render: rowData => {
-                      return (
-                        <Link
-                          to={{
-                            pathname: `/${
-                              rowData.group
-                            }/${rowData.skillTag
-                              .toLowerCase()
-                              .replace(/ /g, '_')}/${rowData.language}`,
-                          }}
-                        >
-                          {rowData.skillName}
-                        </Link>
-                      );
+                    {
+                      title: 'Name',
+                      field: 'name',
+                      render: rowData => {
+                        return (
+                          <Link
+                            to={{
+                              pathname: `/${
+                                rowData.group
+                              }/${rowData.skillTag
+                                .toLowerCase()
+                                .replace(/ /g, '_')}/${rowData.language}`,
+                            }}
+                          >
+                            {rowData.skillName}
+                          </Link>
+                        );
+                      },
                     },
-                  },
-                  { title: 'Type', field: 'type' },
-                  {
-                    title: 'Status',
-                    field: 'status',
-                    render: rowData => {
-                      return (
-                        <FormControl>
-                          <Select value={1} style={{ width: '10rem' }}>
-                            <MenuItem value={1}>Enable</MenuItem>
-                          </Select>
-                        </FormControl>
-                      );
+                    { title: 'Type', field: 'type' },
+                    {
+                      title: 'Status',
+                      field: 'status',
+                      render: rowData => {
+                        return (
+                          <FormControl>
+                            <Select value={1} style={{ width: '10rem' }}>
+                              <MenuItem value={1}>Enable</MenuItem>
+                            </Select>
+                          </FormControl>
+                        );
+                      },
                     },
-                  },
-                ]}
-                data={userSkills.map((skill, index) => {
-                  return {
-                    group: skill.group,
-                    skillTag: skill.skillTag,
-                    language: skill.language,
-                    image: skill.image,
-                    skillName: skill.skillName,
-                    type: skill.type,
-                  };
-                })}
-                options={{
-                  search: false,
-                  toolbar: false,
-                  showFirstLastPageButtons: !isSmallScreen,
-                  headerStyle: {
-                    backgroundColor: '#6fa2ff',
-                    color: '#FFF',
-                    fontSize: '1.2rem',
-                  },
-                }}
-                style={{ margin: '10px' }}
-              />
-            )}
+                  ]}
+                  data={userSkills.map((skill, index) => {
+                    return {
+                      group: skill.group,
+                      skillTag: skill.skillTag,
+                      language: skill.language,
+                      image: skill.image,
+                      skillName: skill.skillName,
+                      type: skill.type,
+                    };
+                  })}
+                  options={{
+                    search: false,
+                    toolbar: false,
+                    showFirstLastPageButtons: !isSmallScreen,
+                    headerStyle: {
+                      backgroundColor: '#6fa2ff',
+                      color: '#FFF',
+                      fontSize: '1.2rem',
+                    },
+                  }}
+                  style={{ margin: '10px' }}
+                />
+              )}
           </TableWrap>
         )}
         {userSkills.length === 0 && !loading && (


### PR DESCRIPTION
Fixes #3229  

Changes: 
- Set proper conditions in `Analytics`, `Skills` and `Ratings` section to display `Material Table` only when some content is available to show.

Demo Link: https://pr-3230-fossasia-susi-web-chat.surge.sh

Screenshots of the change:
**Before Changes**
![scsdv](https://user-images.githubusercontent.com/45489945/71869393-e9946400-3137-11ea-9420-0596d9abacff.png)
 
**After Changes**
![csdc](https://user-images.githubusercontent.com/45489945/71869299-9ae6ca00-3137-11ea-9229-6fcf85ec13f3.png)
