### PR TITLE
Trim skill_name before submitting the skill

### DIFF
--- a/src/components/cms/SkillCreator/SkillWizard.js
+++ b/src/components/cms/SkillCreator/SkillWizard.js
@@ -716,11 +716,11 @@ class SkillWizard extends Component {
       accessToken,
       category,
       language,
-      name,
       file,
       imageUrl,
     } = this.props;
-    let { code } = this.props;
+    let { code, name } = this.props;
+    name = name.trim();
     if (this.mode !== 'edit') {
       code = '::author_email ' + email + '\n' + code;
       if (this.isBotBuilder) {


### PR DESCRIPTION
Fixes #3233 

Changes: 
- Trimmed `skill_name` after fetching from props in `saveClick()`.

Demo Link: https://pr-3234-fossasia-susi-web-chat.surge.sh

**Screenshots**

![final_5e144edfa4082f0015ef9371_372314](https://user-images.githubusercontent.com/45489945/71884430-591d4a00-315e-11ea-9874-8af1cb56f2a6.gif)
