### PR TITLE
Fixed not landing into 1st page of search results

### DIFF
--- a/src/redux/reducers/skills.js
+++ b/src/redux/reducers/skills.js
@@ -171,6 +171,7 @@ export default handleActions(
       return {
         ...state,
         filterType,
+        listPage: 1,
         loadingSkills: true,
       };
     },
@@ -179,6 +180,7 @@ export default handleActions(
       return {
         ...state,
         languageValue,
+        listPage: 1,
         loadingSkills: true,
       };
     },
@@ -236,6 +238,7 @@ export default handleActions(
             skill.skillRating &&
             skill.skillRating.stars.avgStar >= ratingRefine,
         ),
+        listPage: 1,
         ratingRefine,
       };
     },


### PR DESCRIPTION
Fixes #3087 

Changes: Fixed not landing into 1st page of search results

Demo Link: https://pr-3247-fossasia-susi-web-chat.surge.sh

Screenshots of the change: [
Incorrect landing
![incorrect landing](https://user-images.githubusercontent.com/44136704/72179106-5050a080-340a-11ea-8a81-79a0d0e17d68.png)
Correct landing
![correct landing](https://user-images.githubusercontent.com/44136704/72179131-56df1800-340a-11ea-8e11-cb35f3acc091.png)


