### PR TITLE
Username displayed in the navbar

### DIFF
--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -367,7 +367,7 @@ class NavigationBar extends Component {
       isAdmin,
       email,
       userName,
-      userSettingsLoaded,
+      // userSettingsLoaded,
       avatarImgThumbnail,
       history,
       searchState,
@@ -589,11 +589,11 @@ class NavigationBar extends Component {
                             src={userAvatar}
                             size="32"
                           />
-                          {userSettingsLoaded && (
-                            <UserDetail>
-                              {!userName ? email : userName}
-                            </UserDetail>
-                          )}
+                          {/* {userSettingsLoaded && ( */}
+                          <UserDetail>
+                            {!userName ? email : userName}
+                          </UserDetail>
+                          {/* )} */}
                           <ExpandMore
                             style={{
                               display: isMobileView(400) ? 'none' : 'inline',


### PR DESCRIPTION
Fixes #3253 

Changes: Username is now displayed in the navbar

Screenshots of the change: 
![Screenshot from 2020-01-11 19-16-27](https://user-images.githubusercontent.com/35566894/72205977-f8b84080-34ae-11ea-9e32-7129499cf645.png)


