### PR TITLE
Added logout confirm check

### DIFF
--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -361,6 +361,24 @@ class NavigationBar extends Component {
     }));
   };
 
+  onLogout = () => {
+    const { actions } = this.props;
+    actions.openModal({
+      modalType: 'confirm',
+      title: 'Logout',
+      handleConfirm: this.handleLogOut,
+      confirmText: 'Logout',
+      handleClose: actions.closeModal,
+      content: <p>Are you sure you want to log out ?</p>,
+    });
+  };
+
+  handleLogOut = () => {
+    const { actions, history } = this.props;
+    history.push('/logout');
+    actions.closeModal();
+  };
+
   render() {
     const {
       accessToken,
@@ -447,19 +465,16 @@ class NavigationBar extends Component {
             </MenuItem>
           </Link>
         ) : null}
-        <Link to="/logout">
-          <MenuItem>
-            <ListItemIcon>
-              <Exit />
-            </ListItemIcon>
-            <ListItemText>
-              <Translate text="Logout" />
-            </ListItemText>
-          </MenuItem>
-        </Link>
+        <MenuItem onClick={this.onLogout}>
+          <ListItemIcon>
+            <Exit />
+          </ListItemIcon>
+          <ListItemText>
+            <Translate text="Logout" />
+          </ListItemText>
+        </MenuItem>
       </React.Fragment>
     );
-
     let userAvatar = null;
     if (accessToken) {
       userAvatar = avatarImgThumbnail;

--- a/src/components/shared/Dialog/dialogTypes/ConfirmDialog.js
+++ b/src/components/shared/Dialog/dialogTypes/ConfirmDialog.js
@@ -3,21 +3,47 @@ import PropTypes from 'prop-types';
 import DialogActions from '@material-ui/core/DialogActions';
 import DialogContent from '@material-ui/core/DialogContent';
 import DialogTitle from '@material-ui/core/DialogTitle';
-import Button from '@material-ui/core/Button';
+import Button from '../../../shared/Button';
 
 const ConfirmDialog = props => {
-  const { title, content, handleConfirm } = props;
+  const { title, content, handleConfirm, handleClose, confirmText } = props;
   return (
     <React.Fragment>
       <DialogTitle>{title}</DialogTitle>
       <DialogContent>
         <p>{content}</p>
       </DialogContent>
-      <DialogActions>
-        <Button key={1} onClick={handleConfirm}>
-          Ok
-        </Button>
-      </DialogActions>
+      {confirmText ? (
+        <DialogActions>
+          <Button
+            key={0}
+            variant="contained"
+            color="primary"
+            onClick={handleClose}
+          >
+            Cancel
+          </Button>
+          <Button
+            key={1}
+            variant="contained"
+            color="primary"
+            onClick={handleConfirm}
+          >
+            {confirmText}
+          </Button>
+        </DialogActions>
+      ) : (
+        <DialogActions>
+          <Button
+            key={1}
+            variant="contained"
+            color="primary"
+            onClick={handleConfirm}
+          >
+            ok
+          </Button>
+        </DialogActions>
+      )}
     </React.Fragment>
   );
 };
@@ -26,6 +52,8 @@ ConfirmDialog.propTypes = {
   title: PropTypes.string,
   content: PropTypes.string,
   handleConfirm: PropTypes.func,
+  confirmText: PropTypes.string,
+  handleClose: PropTypes.func,
 };
 
 export default ConfirmDialog;


### PR DESCRIPTION
Fixes #3261 

Changes: 
- Added `ConfirmLogOut` dialog for the modal which opens when the **Logout** link is clicked.

Demo Link: https://pr-3262-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
![final_5e1ad94842ff050016e5be7e_607418](https://user-images.githubusercontent.com/45489945/72216219-6793a900-3544-11ea-8a43-ce30cbb30dea.gif)

