### PR TITLE
Password not removed in case of wrong password.

### DIFF
--- a/src/components/Auth/Login/Login.react.js
+++ b/src/components/Auth/Login/Login.react.js
@@ -122,7 +122,7 @@ class Login extends Component {
         } else {
           snackBarMessage = 'Login Failed. Try Again';
           this.setState(prevState => ({
-            password: '',
+            password: password,
             success: false,
             loading: false,
             attempts: prevState.attempts + 1,
@@ -132,7 +132,7 @@ class Login extends Component {
       } catch (error) {
         console.log(error);
         this.setState(prevState => ({
-          password: '',
+          password: password,
           success: false,
           loading: false,
           attempts: prevState.attempts + 1,


### PR DESCRIPTION
Fixes #[Password should not be cleared if it doesn't match #3267] 

Changes: Password is not removed in case of wrong password.


Screenshots of the change: 

![Screenshot (47)](https://user-images.githubusercontent.com/32355917/72352613-95c1e600-3708-11ea-8d1b-616b3e667c0a.png)


