### PR TITLE
Added image crop to crop bot image

### DIFF
--- a/src/components/cms/SkillCreator/SkillWizard.js
+++ b/src/components/cms/SkillCreator/SkillWizard.js
@@ -6,6 +6,7 @@ import TreeView from './SkillViews/TreeView';
 import Preview from '../BotBuilder/Preview/Preview';
 import Button from '../../shared/Button';
 import searchURLPath from '../../../utils/searchURLPath';
+import { base64StringtoFile } from '../../../utils/helperFunctions';
 import getQueryStringValue from '../../../utils/getQueryStringValue';
 import createActions from '../../../redux/actions/create';
 import uiActions from '../../../redux/actions/ui';
@@ -939,24 +940,35 @@ class SkillWizard extends Component {
     // console.log(imageUrl.replace('images/', ''));
   };
 
-  _onChange = event => {
+  _onChange = async event => {
     const { actions } = this.props;
     let { code } = this.props;
     // Assuming only image
     let payload = {};
     let file = this.file.files[0];
-    const image = window.URL.createObjectURL(file);
-    // console.log(file) // Would see a path?
-    let imageUrl = file.name;
-    if (this.props.imageUrl !== `images/${imageUrl}`) {
-      this.setState({
-        imageNameChanged: true,
-      });
-    }
-    const pattern = /^::image\s(.*)$/m;
-    code = code.replace(pattern, `::image images/${imageUrl}`);
-    payload = { ...payload, file, imageUrl, code, image };
-    actions.setSkillData(payload);
+    let image = window.URL.createObjectURL(file);
+    let imageName = file.name;
+
+    await actions.openModal({
+      modalType: 'crop',
+      title: `Crop ${this.isBotBuilder ? 'bot' : 'skill'} image`,
+      handleConfirm: (cropImageUrl, imageBase64) => {
+        image = cropImageUrl;
+        file = base64StringtoFile(imageBase64, imageName);
+        if (this.props.imageUrl !== `images/${imageName}`) {
+          this.setState({
+            imageNameChanged: true,
+          });
+        }
+        const pattern = /^::image\s(.*)$/m;
+        code = code.replace(pattern, `::image images/${imageName}`);
+        payload = { ...payload, file, imageName, code, image };
+        actions.setSkillData(payload);
+        actions.closeModal();
+      },
+      handleClose: actions.closeModal,
+      imagePreviewUrl: image,
+    });
   };
 
   handleCommitMessageChange = event => {


### PR DESCRIPTION
Fixes #3296

Changes:
- Used image crop modal to crop the bot image before upload.

Demo Link: https://pr-3297-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 

![Screenshot from 2020-01-16 22-00-06](https://user-images.githubusercontent.com/45489945/72543417-b1192680-38ab-11ea-9f26-e15c9923ad26.png)

