### PR TITLE
Set content-loaders limit with respect to the window-width

### DIFF
--- a/src/components/cms/BrowseSkill/skillLoader.js
+++ b/src/components/cms/BrowseSkill/skillLoader.js
@@ -9,14 +9,29 @@ const Container = styled.div`
 
 const ContentContainer = styled.div`
   width: 260px;
-  height: 168px;
+  height: '100%';
   margin: 8px;
   border: 0.5px solid #eaeded;
 `;
 
+const loaderLimit = () => {
+  const innerWidth = window.innerWidth;
+  let limit = 2;
+  if (innerWidth >= 1680) {
+    limit = 6;
+  } else if (innerWidth >= 1400) {
+    limit = 5;
+  } else if (innerWidth >= 1120) {
+    limit = 4;
+  } else if (innerWidth >= 840) {
+    limit = 3;
+  }
+  return limit;
+};
+
 const addLoader = () => {
   const loader = [];
-  const limit = isMobileView() ? 2 : 4;
+  const limit = loaderLimit();
   for (let i = 0; i < limit; i++) {
     loader.push(
       <ContentContainer key={i}>


### PR DESCRIPTION
Fixes #3168 

Changes: 
- Set limits to display loaders according to `window.innerWidth()`.

Demo Link: https://pr-3302-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
**After Changes**
![Screenshot from 2020-01-17 14-57-05](https://user-images.githubusercontent.com/45489945/72600881-71e5e680-393a-11ea-9400-99eba8fde155.png)
![Screenshot from 2020-01-17 14-57-18 (1)](https://user-images.githubusercontent.com/45489945/72600888-73171380-393a-11ea-8134-7cedbe948535.png)
![Screenshot from 2020-01-19 10-21-23](https://user-images.githubusercontent.com/45489945/72675113-a0cc9b80-3aa5-11ea-8431-14b4aec8b4bd.png)