### PR TITLE
Fix the ScrollTopButton getting covered by SkillCard elements

### DIFF
--- a/src/components/shared/ScrollTopButton.js
+++ b/src/components/shared/ScrollTopButton.js
@@ -10,6 +10,7 @@ const ScrollTopFab = styled(Fab)`
   top: ${props => props.height - 95 + 'px'};
   right: ${props => (props.width < 1100 ? '70px' : '100px')};
   margin: 15px;
+  z-index: 3000;
 `;
 
 class ScrollTopButton extends React.Component {


### PR DESCRIPTION
Fixes #3309 

Changes: [Add here what changes were made in this pull request and if possible provide links showcasing the changes.]
- Added `z-index: 3000` property to the styled-components CSS of ScrollTopButton

Demo Link: https://pr-3310-fossasia-susi-web-chat.surge.sh

Screenshots of the change: [Add screenshots depicting the changes.]

Before: 
![image](https://user-images.githubusercontent.com/28688352/72652799-881a9380-3988-11ea-85db-45c1282cd975.png)

After:
![image](https://user-images.githubusercontent.com/28688352/72652816-a2547180-3988-11ea-9263-34ccaab9b645.png)


