### PR TITLE
Fixed Social media buttons on share susi menu

### DIFF
--- a/src/components/Settings/ShareOnSocialMedia.js
+++ b/src/components/Settings/ShareOnSocialMedia.js
@@ -1,6 +1,5 @@
 import React, { Component } from 'react';
 import _IconButton from '@material-ui/core/IconButton';
-import DialogTitle from '@material-ui/core/DialogTitle';
 import {
   FacebookShareButton as _FacebookShareButton,
   LinkedinShareButton as _LinkedinShareButton,
@@ -14,12 +13,13 @@ import {
   TelegramIcon,
 } from 'react-share';
 import styled, { css } from 'styled-components';
+import SettingsTabWrapper from './SettingsTabWrapper';
 import CopyWithButton from '../../utils/CopyWithButton';
 import PropTypes from 'prop-types';
 import urls from '../../utils/urls';
 
 const commonIconStyle = css`
-  margin-top: 1rem;
+  margin-top: 0rem;
   display: flex;
   align-items: flex-start;
   width: 100%;
@@ -28,14 +28,25 @@ const commonIconStyle = css`
 
 const ShareIconContainer = styled.div`
   display: flex-wrap;
-  margin: 0.7rem 2.5rem;
+  margin: 0.7rem 0rem;
 `;
 
 const IconButton = styled(_IconButton)`
+  backgroundColor: 'transparent'
   border-radius: 0.125rem;
   padding: 0.5rem;
   font-size: 1rem;
+  &:hover {
+    opacity: 0.5;
+  }
+  &:active {
+    opacity: 1;
+  }
 `;
+
+IconButton.defaultProps = {
+  variant: 'raised',
+};
 
 const FacebookShareButton = styled(_FacebookShareButton)`
   ${commonIconStyle};
@@ -74,65 +85,65 @@ class ShareOnSocialMedia extends Component {
   render() {
     return (
       <React.Fragment>
-        <DialogTitle>Share about SUSI.AI</DialogTitle>
-
-        <CopyWithButton
-          value={this.state.shareText}
-          width={this.props.width}
-          handleChange={this.handleChange}
-        />
-        <ShareIconContainer>
-          <IconButton>
-            <FacebookShareButton
-              url={this.state.shareUrl}
-              quote={this.state.title}
-            >
-              <div>
-                <FacebookIcon size={42} />
-              </div>
-            </FacebookShareButton>
-          </IconButton>
-          <IconButton>
-            <TwitterShareButton
-              url={this.state.shareUrl}
-              title={this.state.title}
-            >
-              <div>
-                <TwitterIcon size={42} />
-              </div>
-            </TwitterShareButton>
-          </IconButton>
-          <IconButton>
-            <LinkedinShareButton
-              url={this.state.shareUrl}
-              title={this.state.title}
-            >
-              <div>
-                <LinkedinIcon size={42} />
-              </div>
-            </LinkedinShareButton>
-          </IconButton>
-          <IconButton>
-            <WhatsappShareButton
-              url={this.state.shareUrl}
-              title={this.state.title}
-            >
-              <div>
-                <WhatsappIcon size={42} />
-              </div>
-            </WhatsappShareButton>
-          </IconButton>
-          <IconButton>
-            <TelegramShareButton
-              url={this.state.shareUrl}
-              title={this.state.title}
-            >
-              <div>
-                <TelegramIcon size={42} />
-              </div>
-            </TelegramShareButton>
-          </IconButton>
-        </ShareIconContainer>
+        <SettingsTabWrapper heading="Share about SUSI.AI">
+          <CopyWithButton
+            value={this.state.shareText}
+            width={this.props.width}
+            handleChange={this.handleChange}
+          />
+          <ShareIconContainer>
+            <IconButton>
+              <FacebookShareButton
+                url={this.state.shareUrl}
+                quote={this.state.title}
+              >
+                <div>
+                  <FacebookIcon size={42} />
+                </div>
+              </FacebookShareButton>
+            </IconButton>
+            <IconButton>
+              <TwitterShareButton
+                url={this.state.shareUrl}
+                title={this.state.title}
+              >
+                <div>
+                  <TwitterIcon size={42} />
+                </div>
+              </TwitterShareButton>
+            </IconButton>
+            <IconButton>
+              <LinkedinShareButton
+                url={this.state.shareUrl}
+                title={this.state.title}
+              >
+                <div>
+                  <LinkedinIcon size={42} />
+                </div>
+              </LinkedinShareButton>
+            </IconButton>
+            <IconButton>
+              <WhatsappShareButton
+                url={this.state.shareUrl}
+                title={this.state.title}
+              >
+                <div>
+                  <WhatsappIcon size={42} />
+                </div>
+              </WhatsappShareButton>
+            </IconButton>
+            <IconButton>
+              <TelegramShareButton
+                url={this.state.shareUrl}
+                title={this.state.title}
+              >
+                <div>
+                  <TelegramIcon size={42} />
+                </div>
+              </TelegramShareButton>
+            </IconButton>
+          </ShareIconContainer>
+        </SettingsTabWrapper>
       </React.Fragment>
     );
   }

--- a/src/utils/CopyWithButton.js
+++ b/src/utils/CopyWithButton.js
@@ -18,13 +18,14 @@ export const StyledIconButton = styled(Button)`
 
 const Container = styled.div`
   display: flex;
-  margin: 0rem 3rem;
-  margin-top: 1rem;
+  margin: 0rem 0rem;
+  margin-top: 2rem;
   margin-bottom: -0.5rem;
 `;
 
 const Text = styled.textarea`
-  width: ${props => (props.width ? props.width : '33%')};
+  width: ${props => (props.width ? props.width : '80%')};
+  min-height: 5rem;
   font-size: 1rem;
   padding: 2px 0.5rem;
   border-top-left-radius: 5px;


### PR DESCRIPTION
Fixes #3328 and Fixes #3326

Changes: [Fixed uniformity in Susi share menu and others
Fixed Social icons in Susi share menu
Fixed hovering action of these in chrome
Fixed overlapping of on hover and click actions]

Screenshots of the change: 
Link : http://pr3342foss.surge.sh/settings

Susi Share menu and On Click :
![Screenshot from 2020-01-19 18-12-45](https://user-images.githubusercontent.com/42002993/72681220-6683ee00-3ae7-11ea-9967-f5c12a49ed9b.png)

On hover:
![Screenshot from 2020-01-19 18-11-22](https://user-images.githubusercontent.com/42002993/72681239-81eef900-3ae7-11ea-948d-ffacbf5c7b37.png)


