### PR TITLE
fix(): made buttons symmetric/uniform

### DIFF
--- a/src/components/About/Overview/index.js
+++ b/src/components/About/Overview/index.js
@@ -27,7 +27,7 @@ import Web from '@material-ui/icons/Web';
 import GIF from '@material-ui/icons/Gif';
 import LocationOn from '@material-ui/icons/LocationOn';
 import Action from '@material-ui/icons/ChatBubble';
-import Button from '@material-ui/core/Button';
+import _Button from '@material-ui/core/Button';
 import PlusOne from '@material-ui/icons/PlusOne';
 import Search from '@material-ui/icons/Search';
 import googlePlay from '../../../images/google-play.svg';
@@ -35,6 +35,11 @@ import appStore from '../../../images/app-store.svg';
 import './Overview.css';
 import styled, { css } from 'styled-components';
 import { withStyles } from '@material-ui/core/styles';
+
+const Button = styled(_Button)`
+  width: 30%;
+  margin: 4px;
+`;
 
 const commonDesc = css`
   text-align: left;
@@ -289,6 +294,7 @@ const RowDiv = styled.div`
 
   @media (max-width: 480px) {
     width: auto;
+    justify-content: flex-start;
   }
 `;
 
@@ -655,8 +661,13 @@ class Overview extends Component {
                   key={index}
                   style={
                     gifIndex === index
-                      ? { backgroundColor: '#4285f4', color: '#ffffff' }
-                      : { backgroundColor: '#ffffff' }
+                      ? {
+                          backgroundColor: '#4285f4',
+                          color: '#ffffff',
+                        }
+                      : {
+                          backgroundColor: '#ffffff',
+                        }
                   }
                   variant="contained"
                   onClick={e => this.handleGIFChange(index)}


### PR DESCRIPTION
Fixes #3088 

Changes: Changed CSS made the button grid more uniform across all devices.

Demo Link: https://pr-3344-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
<img width="477" alt="Screenshot 2020-01-21 at 1 05 40 AM" src="https://user-images.githubusercontent.com/20151526/72753385-d4650e00-3bea-11ea-803d-3a91669400af.png">
<img width="443" alt="Screenshot 2020-01-21 at 1 05 46 AM" src="https://user-images.githubusercontent.com/20151526/72753386-d4650e00-3bea-11ea-84a6-fb8f83dfecbb.png">
<img width="813" alt="Screenshot 2020-01-21 at 1 05 55 AM" src="https://user-images.githubusercontent.com/20151526/72753387-d4650e00-3bea-11ea-9d17-00041c9f679f.png">




