### PR TITLE
Username displayed in the navbar

### DIFF
--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -606,7 +606,7 @@ class NavigationBar extends Component {
                           />
                           {userSettingsLoaded && (
                             <UserDetail>
-                              {!userName ? email : userName}
+                              {userName ? userName : email}
                             </UserDetail>
                           )}
                           <ExpandMore


### PR DESCRIPTION
Fixes #3253 

Changes: Username is now displayed instead of email in the navbar

Demo Link: https://pr-3355-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
![Screenshot from 2020-01-21 23-16-50](https://user-images.githubusercontent.com/43489708/72829125-24ec7200-3ca4-11ea-82a6-8fedc81b9a12.png)
