### PR TITLE
The text remains visible now during webfont load

### DIFF
--- a/public/css/material_icons.css
+++ b/public/css/material_icons.css
@@ -4,6 +4,7 @@
   font-style: normal;
   font-weight: 400;
   src: url(../fonts/material_icons.woff) format('woff2');
+  font-display: swap;
 }
 
 .material-icons {

--- a/public/index.html
+++ b/public/index.html
@@ -491,6 +491,7 @@
         font-style: normal;
         font-weight: 400;
         src: url(./fonts/material_icons.woff) format('woff2');
+        font-display: swap;
       }
 
       .material-icons {


### PR DESCRIPTION
Fixes #3459 

Changes: 
The font now displayed immediately is a system font. Once the custom font is ready, it replaces the system font.

Demo Link: https://pr-3460-fossasia-susi-web-chat.surge.sh

