### PR TITLE
Fixes category reset link

### DIFF
--- a/src/components/cms/BrowseSkill/BrowseSkill.js
+++ b/src/components/cms/BrowseSkill/BrowseSkill.js
@@ -146,7 +146,7 @@ const SidebarText = styled.h4`
   ${SidebarTextStyles}
 `;
 
-const SidebarLink = styled.button`
+const SidebarLink = styled(Link)`
   color: rgba(0, 0, 0, 0.54);
   font-weight: bold;
   border: none;


### PR DESCRIPTION
Fixes #3456 
Fixes #3469 

Changes: The sidebar link was styled as button before. However it should be link. This was causing links not to work.

Screenshots of the change:

![solved](https://user-images.githubusercontent.com/42002993/74533566-e58a0c00-4f57-11ea-872d-69b0d6289964.gif)


