### PR TITLE
Fixed sidebar toggler position (#3096)

### DIFF
--- a/src/components/cms/BrowseSkill/SideDrawer.js
+++ b/src/components/cms/BrowseSkill/SideDrawer.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { makeStyles } from '@material-ui/core/styles';
+import Fab from '@material-ui/core/Fab';
 import SwipeableDrawer from '@material-ui/core/SwipeableDrawer';
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
@@ -13,11 +14,14 @@ const useStyles = makeStyles({
   },
 });
 
-const Button = styled.button`
-  float: right;
+const Button = styled(Fab)`
+  position: fixed;
+  bottom: 16.5px;
+  float: left;
   margin: 0.5rem 1rem;
-  border-radius: 5px;
+  border-radius: 50%;
   background-color: #4285f4;
+  z-index: 89;
 `;
 
 const Icon = styled.i`


### PR DESCRIPTION
Fixes #3096 

Changes: The sidebar toggler on smaller screens should remain fixed for smaller screens. The CSS in JS was changed to allow this to happen.

__Before__ :
![File-animation-before](https://user-images.githubusercontent.com/41413622/74583745-4107d880-4ff0-11ea-9406-a043e9313fdf.gif)

__After__
![File-animation](https://user-images.githubusercontent.com/41413622/74583773-8926fb00-4ff0-11ea-9520-e2ab1f6f8ec9.gif)


Demo Link: https://pr-3474-fossasia-susi-web-chat.surge.sh


