### PR TITLE
Fixed slide show button

### DIFF
--- a/src/components/cms/SkillSlideshow/index.css
+++ b/src/components/cms/SkillSlideshow/index.css
@@ -13,7 +13,7 @@ right: 0.25rem !important;
   z-index: 10;
   color: #757575;
   width: 3rem;
-  height: 3rem;
+  height: 100%;
 }
 
 .slick-next:hover, .slick-prev:hover {


### PR DESCRIPTION
Fixes #3371

Changes: Previously, the button when clicked on extremes (top/bottom) navigated user to other pages which is not desirable from users perspective. When not visible, any image on slide show should not navigate the user to that link and rather show that image first.

Demo Link: 

Screenshots of the change: 
Now : - 
![after](https://user-images.githubusercontent.com/42002993/74598401-eaa1a500-5096-11ea-9b1d-6579f6ef8ee6.gif)

Before : -
![before](https://user-images.githubusercontent.com/42002993/74598407-0d33be00-5097-11ea-8dc4-e6a2101902da.gif)




