### PR TITLE
Adding Space between icon and text in the footer of each blog

### DIFF
--- a/src/components/About/Blog/BlogItem.js
+++ b/src/components/About/Blog/BlogItem.js
@@ -302,7 +302,7 @@ const BlogItem = ({ posts }) => {
           <FlexBox>
             <Icon className="fa fa-calendar" />
             <BlogFooterLink href={posts.link}>
-              {dateFormat(d, 'mmmm dd, yyyy')}
+              &nbsp; {dateFormat(d, 'mmmm dd, yyyy')}
             </BlogFooterLink>
           </FlexBox>
           <FlexBox>
@@ -311,16 +311,16 @@ const BlogItem = ({ posts }) => {
               rel="noopener noreferrer"
               href={'http://blog.fossasia.org/author/' + posts.author}
             >
-              {posts.author}
+              &nbsp; {posts.author}
             </BlogFooterLink>
           </FlexBox>
           <FlexBox>
             <Icon className="fa fa-folder-open-o" />
-            {fCategory}
+            &nbsp; {fCategory}
           </FlexBox>
           <FlexBox>
             <Icon className="fa fa-tags" />
-            <div>{ftags}</div>
+            <div> &nbsp; {ftags}</div>
           </FlexBox>
         </BlogFooter>
       </Card>


### PR DESCRIPTION


Fixes #3483 

Changes: 
Adding Space between icon and text in the footer of each blog i the Blog Section.

Demo Link: https://pr-[3484]-fossasia-susi-web-chat.surge.sh

Screenshots of the change:

**Before**
![Screenshot 2020-02-16 12:14:20](https://user-images.githubusercontent.com/35539313/74600402-1c2a6880-50b7-11ea-9280-612b6b476c2f.png)

**After**
![Screenshot 2020-02-16 12:16:55](https://user-images.githubusercontent.com/35539313/74600383-d4a3dc80-50b6-11ea-98d5-7e3768d68b45.png)