### PR TITLE
Change the background color of card in Team section Page

### DIFF
--- a/src/components/About/Team/index.js
+++ b/src/components/About/Team/index.js
@@ -40,6 +40,7 @@ const Section = styled.div`
 const Card = styled(_Card)`
   margin: 0.625rem 0.625rem 0 0;
   max-width: 14.688rem;
+  background-color: #d5d6d6;
 
   @media (max-width: 1000px) {
     max-width: 15rem;


### PR DESCRIPTION
Fixes #3485 

Changes: 

Change the background color of card in Team section Page to make it distinguish from background of page.

Screenshots of the change:

**Before
![Screenshot 2020-02-16 12:30:34](https://user-images.githubusercontent.com/35539313/74600699-38c89f80-50bb-11ea-812f-79480341e011.png)
**

**After**
![Screenshot 2020-02-16 12:48:46](https://user-images.githubusercontent.com/35539313/74600701-40884400-50bb-11ea-9e05-036ba30bcab5.png)
