### PR TITLE
Fixed unnecessary link in navbar to about menu

### DIFF
--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -744,16 +744,14 @@ class NavigationBar extends Component {
                       </Link>
                     </Paper>
                   </Popper>
-                  <Link to="/about">
-                    <IconButton
-                      aria-haspopup="true"
-                      style={{
-                        color: 'white',
-                      }}
-                    >
-                      <ContactSupportIcon />
-                    </IconButton>
-                  </Link>
+                  <IconButton
+                    aria-haspopup="true"
+                    style={{
+                      color: 'white',
+                    }}
+                  >
+                    <ContactSupportIcon />
+                  </IconButton>
                 </div>
               </TopRightMenuContainer>
             </Toolbar>


### PR DESCRIPTION
Fixes #3487

Changes: 
Removed unnecessary navigation on clicking "?".

Screenshots of the change:

![after](https://user-images.githubusercontent.com/42002993/74603958-311af200-50df-11ea-8446-1f4500065d5e.gif)


