### PR TITLE
Adding space in between buttons in Delete dialog-box.

### DIFF
--- a/src/components/Auth/DeleteAccount/DeleteAccount.react.js
+++ b/src/components/Auth/DeleteAccount/DeleteAccount.react.js
@@ -24,6 +24,9 @@ const DeleteButton = styled(Button)`
   :hover {
     background-color: #b20000;
   }
+  @media (max-width: 430px) {
+    margin-bottom: 1rem;
+  }
 `;
 
 class DeleteAccount extends Component {


### PR DESCRIPTION
Fixes #3495 

Changes:
Added a space between both the buttons in `delete dialog-box` in mobile view

Demo Link: https://pr-[3496]-fossasia-susi-web-chat.surge.sh

Screenshots of the change: [Add screenshots depicting the changes.]

**Before**
![Screenshot 2020-02-17 16:58:20](https://user-images.githubusercontent.com/35539313/74652942-23cc3900-51ad-11ea-9c89-006ea9f9f0e0.png)

**After**
![Screenshot 2020-02-17 17:33:30](https://user-images.githubusercontent.com/35539313/74652951-2890ed00-51ad-11ea-8591-e8126e4c81d4.png)

_Note: Ignore the different bgcolor in both the pictures as I change the theme earlier_