### PR TITLE
Fixes #3491 Prevents page auto scroll

### DIFF
--- a/src/components/cms/BotBuilder/Preview/Preview.js
+++ b/src/components/cms/BotBuilder/Preview/Preview.js
@@ -252,15 +252,8 @@ class Preview extends Component {
 
   componentDidMount = () => {
     this.updateWindowDimensions();
-    this.scrollToBottom();
     window.addEventListener('resize', this.updateWindowDimensions);
   };
-
-  componentDidUpdate() {
-    if (this.messageEndRef.current) {
-      this.scrollToBottom();
-    }
-  }
 
   togglePreview = () => {
     this.setState(prevState => ({
@@ -368,11 +361,6 @@ class Preview extends Component {
 
   replaceAll = (str, find, replace) => {
     return str.replace(new RegExp(this.escapeRegExp(find), 'g'), replace);
-  };
-
-  // Scroll to the bottom
-  scrollToBottom = () => {
-    this.messageEndRef.current.scrollIntoView({ behavior: 'smooth' });
   };
 
   componentWillUnmount = () => {


### PR DESCRIPTION
Fixes #3491 

Changes: 
On any state change, the whole window scrolled to the bottom on the Create Skill page. This PR fixes that.

__Changed behaviour__
![File-animation-Scroll-After](https://user-images.githubusercontent.com/41413622/74667208-e8d7fe80-51c8-11ea-8654-9373575b009e.gif)


Demo Link: https://pr-3499-fossasia-susi-web-chat.surge.sh


