### PR TITLE
Removed horizontal scrollbars on Edge and Firefox

### DIFF
--- a/src/components/Settings/Settings.react.js
+++ b/src/components/Settings/Settings.react.js
@@ -51,7 +51,11 @@ const Container = styled.div`
   width: 100%;
   min-height: calc(100vh - 48px);
   margin-top: 2rem;
-  overflow: auto;
+  overflow: visible;
+  overflow-style: none;
+  -ms-overflow-style: none;
+  overflow: -moz-scrollbars-none;
+  scrollbar-width: none;
   background: ${props => (props.theme === 'dark' ? '#000012' : '#f2f2f2')};
   @media only screen and (max-width: 1060px) {
     height: 100vh;

--- a/src/components/cms/SkillCardScrollList/SkillCard.js
+++ b/src/components/cms/SkillCardScrollList/SkillCard.js
@@ -27,12 +27,16 @@ const ScrollWrapper = styled.div`
   margin: 0.625rem;
   overflow-x: scroll;
   overflow-y: hidden;
+  -ms-overflow-style: none;
+  overflow: -moz-scrollbars-none;
+  scrollbar-width: none;
+  scroll-behavior: smooth;
+  overflow-style: none;
   white-space: nowrap;
   &::-webkit-scrollbar {
     display: none;
   }
 `;
-
 const LeftFab = styled(Fab)`
   position: absolute;
   left: 16rem;


### PR DESCRIPTION
Fixes #3506 

Changes:
The current codebase only hid the horizontal scrollbars on the Browse Skills container in Chrome only. This PR enables that feature across Edge and Firefox as well. 

Demo Link: https://pr-3509-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 

__Mozilla Firefox__
![File-Scroll-Bar-Solved-Firefox](https://user-images.githubusercontent.com/41413622/74921898-6b90d180-53f4-11ea-80ff-cf1f6ba8a1d3.gif)

__Microsoft Edge__
![File-Scroll-Bar-Solved-Edge](https://user-images.githubusercontent.com/41413622/74921916-76e3fd00-53f4-11ea-9cae-5ec4444fc12f.gif)


