### PR TITLE
Resolved highlighting error in chat

### DIFF
--- a/src/components/ChatApp/MessageSection/MessageSection.react.js
+++ b/src/components/ChatApp/MessageSection/MessageSection.react.js
@@ -599,7 +599,7 @@ class MessageSection extends Component {
   ) => {
     // markID indicates search mode on
     const { mode } = this.props;
-    if (markID && Array.isArray(markID) && markID.length > 0) {
+    if (markID) {
       return messages.map(id => {
         return (
           <MessageListItem


### PR DESCRIPTION
Fixes #3510 

Changes: markId variable in MessageSection.react.js is not an array typed. Removed Array.isArray() and markId.length from the if condition. If it's not null,relevant text will be highlighted in searching.

Demo Link: https://pr-3513-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
![Screenshot from 2020-04-05 13-46-44](https://user-images.githubusercontent.com/43112139/78470066-0e52a480-7744-11ea-8194-fae258d128ef.png)



