### PR TITLE
Fixed: Rating star doesn't matches with original one on applying rating filters

### DIFF
--- a/src/components/cms/SkillCardList/SkillCardList.js
+++ b/src/components/cms/SkillCardList/SkillCardList.js
@@ -267,6 +267,8 @@ function createListCard(
                       <Ratings.Widget />
                       <Ratings.Widget />
                       <Ratings.Widget />
+                      <Ratings.Widget />
+                      <Ratings.Widget />
                       <ReactTooltip
                         className="customeTheme"
                         id={dataId}
@@ -278,8 +280,6 @@ function createListCard(
                       >
                         <SkillRatingPopover stars={stars} />
                       </ReactTooltip>
-                      <Ratings.Widget />
-                      <Ratings.Widget />
                     </Ratings>
                     <NavigationArrowDropDown
                       style={{


### PR DESCRIPTION
Fixes #3539 

Demo Link: https://pr-3539-fossasia-susi-web-chat.surge.sh

Changes:
Grouping Rating.widget at one place and then added the ReactTooltip after that.

Screenshots of the change:
![DeepinScreenshot_20200511223125](https://user-images.githubusercontent.com/37840881/81589675-3c787380-93d7-11ea-852f-c584a5ff11ab.png)


