### PR TITLE
fix: tooltip delay to avoid moving with cursor - I3541

### DIFF
--- a/src/components/cms/SkillCardList/SkillCardList.js
+++ b/src/components/cms/SkillCardList/SkillCardList.js
@@ -273,7 +273,6 @@ function createListCard(
                         type={'light'}
                         place="bottom"
                         effect="solid"
-                        delayHide={250}
                         border={true}
                       >
                         <SkillRatingPopover stars={stars} />


### PR DESCRIPTION
Fixes #3541 

Changes: 
- Removed the react-tooltip ```delay``` property to immediately hide the rating tooltip instead of being dragged around with the cursor 

Demo Link: https://pr-3543-fossasia-susi-web-chat.surge.sh

Changes made:
![Tooltips-Fixed-2](https://user-images.githubusercontent.com/41413622/81825841-beda7200-9554-11ea-8105-97dc68457479.gif)



