### PR TITLE
Adding space in between the skill bubble on the skill page in mobile view

### DIFF
--- a/src/components/cms/SkillPage/SkillListing.js
+++ b/src/components/cms/SkillPage/SkillListing.js
@@ -55,7 +55,7 @@ const Paper = styled(_Paper)`
 `;
 
 const ExampleWrapper = styled.div`
-  width: 55%;
+  width: 100%;
   display: flex;
   flex-wrap: wrap;
   flex-direction: row;
@@ -359,7 +359,7 @@ class SkillListing extends Component {
                       key={index}
                       data={data}
                       history={history}
-                      margin={'1.5% 2.85% 1.5% 0'}
+                      margin={'12px 10px 12px 0'}
                     />
                   );
                 })}


### PR DESCRIPTION
Fixes #3552 

Changes: Added space in between the skill bubbles and width of the skill bubble section changed to 100%.

Demo Link: https://pr-3552-fossasia-susi-web-chat.surge.sh

Screenshots:
**Before**
![WhatsApp Image 2020-05-22 at 22 17 45](https://user-images.githubusercontent.com/37840881/82696296-5b52f180-9c84-11ea-9260-51a13d205c40.jpeg)

**After**
![WhatsApp Image 2020-05-22 at 23 29 10](https://user-images.githubusercontent.com/37840881/82696325-6ad23a80-9c84-11ea-94c9-5348e08e985e.jpeg)
