### PR TITLE
fix: burger menu icon shows up between 768px and  520 px 

### DIFF
--- a/src/components/cms/BrowseSkill/BrowseSkill.js
+++ b/src/components/cms/BrowseSkill/BrowseSkill.js
@@ -603,7 +603,7 @@ class BrowseSkill extends React.Component {
       loadingSkills,
     } = this.props;
     const { routeType, routeValue, history } = this.props;
-    let isMobile = isMobileView();
+    let isMobile = isMobileView(768);
     let backToHome = null;
     let renderMenu = null;
     let renderMobileMenu = null;


### PR DESCRIPTION
Fixes #3594 

Changes: Passed parameter as 768 to isMobileView function for getting burger menu icon to be displayed for screen width less than 768px.

Demo Link: https://pr-3600-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 
**Before**
![Initi](https://user-images.githubusercontent.com/40193621/93332274-3c81f780-f83f-11ea-9f8d-a44a83e60181.png)
Here, No icon is present for screen width less than 768px.

**After**
![Final](https://user-images.githubusercontent.com/40193621/93332337-53c0e500-f83f-11ea-9009-eb3778a20513.png)
Here, menu icon is visible for screen width less than 768px.
