### PR TITLE
pass-field changed

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "4.17.19",
     "material-table": "1.60.0",
     "material-ui-color-picker": "3.5.0",
-    "material-ui-password-field": "2.1.1",
+    "material-ui-password-field": "2.1.2",
     "material-ui-search-bar": "1.0.0-beta.13",
     "md5": "2.2.1",
     "moment": "2.26.0",


### PR DESCRIPTION
Fixes #3584 

Changes: "**material-ui-password-field": "2.1.1"** has been changed to **"material-ui-password-field": "2.1.2"** which fixes toggle password in newer react versions. [Material-ui-password-field](https://github.com/TeamWertarbyte/material-ui-password-field)

Demo Link: http://pr-3606-fossasia-susi-web-chat.surge.sh/

Screenshots of the change: 

> Before
![before](https://user-images.githubusercontent.com/39864404/97749684-7cfab380-1b15-11eb-97a5-4a0748974f1f.PNG)

> After
![after](https://user-images.githubusercontent.com/39864404/97749798-af0c1580-1b15-11eb-8ace-6e8976b1f03b.PNG)




