### PR TITLE
Toggle fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "lodash": "4.17.19",
     "material-table": "1.60.0",
     "material-ui-color-picker": "3.5.0",
-    "material-ui-password-field": "2.1.1",
+    "material-ui-password-field": "2.1.2",
     "material-ui-search-bar": "1.0.0-beta.13",
     "md5": "2.2.1",
     "moment": "2.26.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9293,10 +9293,10 @@ material-ui-color-picker@3.5.0:
     react-color "^2.18.0"
     recompose "^0.30.0"
 
-material-ui-password-field@2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/material-ui-password-field/-/material-ui-password-field-2.1.1.tgz#777126900236f30f54913e1d23bf57fdd95a2591"
-  integrity sha512-+PnFzhcEtaksQDdEZCv0y8qeFSjixPjvpkJlbZCPDiN65SD0bU3jLOX9e/6/5OpZFOqQ6zfMxtHosCLqqMK2jw==
+material-ui-password-field@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/material-ui-password-field/-/material-ui-password-field-2.1.2.tgz#9f5abcc540a9bf46f8def3e2eea09bba905c8db6"
+  integrity sha512-7xRCxn4gub+6jiFUDtoPDDqEsWiDsSZnRJPAhO8SzKokqv4wp8efGQ1OoQ7gL2bRM+Vd4Q5ie82BYlwPaYYNYQ==
   dependencies:
     "@material-ui/icons" "^1.0.0"
     material-ui-toggle-icon "^1.0.6"


### PR DESCRIPTION
Fixes #3584 

Changes: "*material-ui-password-field": "2.1.1"* has been changed to *"material-ui-password-field": "2.1.2"* which fixes toggle password in newer react versions. [Material-ui-password-field](https://github.com/TeamWertarbyte/material-ui-password-field)

Demo Link: http://pr-3608-fossasia-susi-web-chat.surge.sh/

Screenshots of the change: 

> Before
![before](https://user-images.githubusercontent.com/39864404/97749684-7cfab380-1b15-11eb-97a5-4a0748974f1f.PNG)

> After
![after](https://user-images.githubusercontent.com/39864404/97749798-af0c1580-1b15-11eb-8ace-6e8976b1f03b.PNG)