### PR TITLE
Yarn made optional. fixes (fossasia#3612)

### DIFF
--- a/package.json
+++ b/package.json
@@ -135,7 +135,8 @@
     "webpack": "^4.41.5",
     "webpack-cli": "^3.3.10",
     "webpack-dev-server": "^3.10.1",
-    "webpack-merge": "^4.2.2"
+    "webpack-merge": "^4.2.2",
+    "yarn": "^1.22.10"
   },
   "scripts": {
     "start": "webpack-dev-server --open --env.mode development",
@@ -144,9 +145,9 @@
     "lint": "eslint \"src/**/*.js\"",
     "precommit": "lint-staged",
     "format": "prettier --write \"src/**/*.js\"",
-    "test": "yarn lint && react-scripts test --env=jsdom",
+    "test": "yarn || npm run lint && react-scripts test --env=jsdom",
     "eject": "react-scripts eject",
-    "predeploy": "yarn build",
+    "predeploy": "yarn || npm run build",
     "deploy": "surge"
   },
   "lint-staged": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -15200,6 +15200,11 @@ yargs@^13.3.0, yargs@^13.3.2:
     y18n "^4.0.0"
     yargs-parser "^13.1.2"
 
+yarn@^1.22.10:
+  version "1.22.10"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.22.10.tgz#c99daa06257c80f8fa2c3f1490724e394c26b18c"
+  integrity sha512-IanQGI9RRPAN87VGTF7zs2uxkSyQSrSPsju0COgbsKQOOXr5LtcVPeyXWgwVa0ywG3d8dg6kSYKGBuYK021qeA==
+
 youtube-player@5.5.2:
   version "5.5.2"
   resolved "https://registry.yarnpkg.com/youtube-player/-/youtube-player-5.5.2.tgz#052b86b1eabe21ff331095ffffeae285fa7f7cb5"


### PR DESCRIPTION
Fixes #3612 
I have made changes to `package.json` to make yarn optional to run project.
Yarn still is a  preferred package manager but `npm scripts` doesn't break if developer doesn't have yarn installed globally.
Instead now, developer installing project with `npm install` have a local installation of `yarn` in project.
Even if he doesnot have yarn globally or locally, he can still run `npm test` and `npm run predeploy` as scripts are modified to fallback to `npm` if `yarn` is not installed.

Changes: 

Situation:
After cloning and running `npm install`
if we run `npm run test` or `npm run predeploy`

Before:
![Screenshot from 2020-12-10 17-29-56](https://user-images.githubusercontent.com/24855641/101775689-d9d68a00-3b15-11eb-95a5-cc7c816960dc.png)

![npm run predeploy](https://user-images.githubusercontent.com/24855641/101775683-d6430300-3b15-11eb-9093-470d442a621a.png)
Now:
![Screenshot from 2020-12-10 18-34-04](https://user-images.githubusercontent.com/24855641/101776054-5d907680-3b16-11eb-9acb-86af8e7c983a.png)
![Screenshot from 2020-12-10 18-34-34](https://user-images.githubusercontent.com/24855641/101776063-5ff2d080-3b16-11eb-9266-b1001e1de9af.png)



Demo Link: https://pr-3613-fossasia-susi-web-chat.surge.sh

