### PR TITLE
SUSI.AI logo doesnot reloads entire page now fixes (#3619)

### DIFF
--- a/src/components/NavigationBar/index.js
+++ b/src/components/NavigationBar/index.js
@@ -579,9 +579,9 @@ class NavigationBar extends Component {
             <Toolbar variant="dense">
               <FlexContainer>
                 <SusiLogoContainer isSearchOpen={search}>
-                  <a href="/" style={{ outline: '0' }}>
+                  <Link to="/" style={{ outline: '0' }}>
                     {renderSusiIcon}
-                  </a>
+                  </Link>
                 </SusiLogoContainer>
               </FlexContainer>
               {renderSearchBar}


### PR DESCRIPTION
Fixes #3619

SUSI.AI logo reloads the entire web app which leads to slower user experience, unneccessary network usage and performance issues

Changes: 
* SUSI.AI logo doesnot reloads the entire web app

Demo Link: https://pr-3620-fossasia-susi-web-chat.surge.sh

Before:
![ezgif com-gif-maker](https://user-images.githubusercontent.com/24855641/102636660-f0668c00-417a-11eb-8797-92d635af739c.gif)

Now:
![ezgif com-gif-maker (1)](https://user-images.githubusercontent.com/24855641/102636742-0aa06a00-417b-11eb-98c5-0fd13d71dcd9.gif)


