### PR TITLE
High resolution content disappearing bug fix (fossasia#3519)

### DIFF
--- a/src/components/cms/BrowseSkill/BrowseSkill.js
+++ b/src/components/cms/BrowseSkill/BrowseSkill.js
@@ -138,9 +138,10 @@ const SidebarItem = styled(MenuItem)`
 `;
 
 const Sidebar = styled.div`
-  width: 16rem;
+  width: 15%;
   display: block;
   z-index: 2;
+  flex: 1 1 0;
   border-right: 1px solid #ddd;
   border-spacing: 1px;
   @media (max-width: 768px) {
@@ -215,15 +216,8 @@ const FlexContainer = styled.div`
 
 const RightContainer = styled.div`
   margin: 1rem 0;
-  @media (max-width: 2400px) {
-    width: 89%;
-  }
-  @media (max-width: 1900px) {
-    width: 86%;
-  }
-  @media (max-width: 1600px) {
-    width: 83.5%;
-  }
+  flex: 1 1 0;
+  width: 85%;
   @media (max-width: 768px) {
     width: 100%;
   }

--- a/src/components/cms/SkillCardScrollList/SkillCard.js
+++ b/src/components/cms/SkillCardScrollList/SkillCard.js
@@ -74,27 +74,44 @@ class SkillCard extends Component {
   };
 
   componentDidMount = () => {
+    window.addEventListener('resize', () => {
+      this.updateWindowDimensions();
+      this.updateBtnsDisplay();
+    });
     this.updateWindowDimensions();
   };
 
   updateWindowDimensions = () => {
     let scrollCards = 1;
-    switch (true) {
-      case window.innerWidth >= 1680:
-        scrollCards = 5;
+    /*          X coordinate of end of a skillCard placed at nth position in a row is calculated
+                using formula `window.innerWidth * 0.15 + 19 + n * 280`
+                Formula is explained pictorially with the diagram below:
+
+                =================================================================================================
+                ||                      SUSI.AI (HOME PAGE) URL - https://susi.ai/                             ||
+                =================================================================================================
+                ||      SIDEBAR (15% width)       |  M   |               RIGHT CONTAINER                       ||
+                ||                                |  A   |--------                                             ||
+                ||                                |  R   | 280   | <-- SkillCard (margin is included in 280px) ||                                           ||
+                ||  css ->  `width : 15%`         |  G   | PX    |                                             ||
+                ||  converts to                   |  I   |--------                                             ||
+                ||  `window.innerWidth * 0.15`    |  N   |-------------------------------                      ||
+                ||   in javascript                |      | 280   |  280 |  280  |  nth  |                      ||
+                ||                                |  19  |  PX   |   PX |  PX   |  card |                      ||
+                ||                                |  px  |------------------------------|                      ||
+                =================================================================================================
+ X coordinate = ||<--  window.innerWidth * 0.15-->|<19px>|<---        280 * n        --->                      ||
+                =================================================================================================
+                When window.innerWidth is more than x coordinate of right end of card at nth position.
+                Maximum scrollCards that can be viewed on that viewport is set to n
+      */
+    // Correct positioning of Right arrow for SkillCards upto MAX_CARDS_SUPPORTED is supported with this for loop.
+    const MAX_CARDS_SUPPORTED = 20;
+    for (let i = MAX_CARDS_SUPPORTED; i > 1; i--) {
+      if (window.innerWidth >= window.innerWidth * 0.15 + 19 + i * 280) {
+        scrollCards = i;
         break;
-      case window.innerWidth >= 1400:
-        scrollCards = 4;
-        break;
-      case window.innerWidth >= 1120:
-        scrollCards = 3;
-        break;
-      case window.innerWidth >= 840:
-        scrollCards = 2;
-        break;
-      default:
-        scrollCards = 1;
-        this.setState({ rightBtnDisplay: 'inline' });
+      }
     }
 
     this.setState(
@@ -264,13 +281,23 @@ class SkillCard extends Component {
         );
       },
     );
-    if (cards.length <= this.state.scrollCards) {
-      this.setState({ rightBtnDisplay: 'none', leftBtnDisplay: 'none' });
-    }
-    this.setState({
-      cards,
-    });
+    this.setState(
+      {
+        cards,
+      },
+      () => {
+        this.updateBtnsDisplay();
+      },
+    );
   };
+
+  updateBtnsDisplay() {
+    if (this.state.cards.length <= this.state.scrollCards) {
+      this.setState({ rightBtnDisplay: 'none', leftBtnDisplay: 'none' });
+    } else if (this.state.cards.length > this.state.scrollCards) {
+      this.setState({ rightBtnDisplay: 'inline' });
+    }
+  }
 
   render() {
     const { leftBtnDisplay, rightBtnDisplay, cards } = this.state;


### PR DESCRIPTION
### Fixes #3519
Content disappering on resolution > 2400px is fixed with this PR.

##### Changes: 
- Content at home page which used to disappear at width > 2400px doesn't disappear now.

#### What was wrong?
- Width of right container on home page was only defined upto 2400px.
<img src="https://user-images.githubusercontent.com/24855641/102686262-6c5ce480-420c-11eb-8f64-500099ff512a.png" width="300px" >
- Due to lack of specified width for screens > 2400px, the right container div gets automatically enlarged.
<img src="https://user-images.githubusercontent.com/24855641/102686276-7aab0080-420c-11eb-8f46-7351b910d191.png" 
  width="400px" />

- Which results in disappearing of content for the user.

#### What I did?
- I removed the media queries specifying different widths for different screen sizes.
- Instead I used relative width for sidebar(15%) and right container(85%) with flexbox .
- Now the width changes properly with different screen sizes.

Before:
At 2401px:
![before](https://user-images.githubusercontent.com/24855641/102686392-7b906200-420d-11eb-817c-9f3adba87fb2.png)
At 4000px:
![Screenshot from 2020-12-19 15-17-29](https://user-images.githubusercontent.com/24855641/102686394-81864300-420d-11eb-9508-dd1193fbdc2c.png)

Now:
At 2401px:
![Screenshot from 2020-12-19 15-18-03](https://user-images.githubusercontent.com/24855641/102686398-8b0fab00-420d-11eb-8843-e2340730be33.png)
At 4000px:
![Screenshot from 2020-12-19 15-18-18](https://user-images.githubusercontent.com/24855641/102686404-8f3bc880-420d-11eb-96ce-63b351e8f4fd.png)

Demo Link: https://pr-3621-fossasia-susi-web-chat.surge.sh
