### PR TITLE
Added debugging support with webpack source-maps fixes (fossasia#3622)

### DIFF
--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
   },
   "scripts": {
     "start": "webpack-dev-server --open --env.mode development",
+    "debug": "webpack-dev-server --open --env.mode development --devtool source-map",
     "docker-start": "webpack-dev-server --host 0.0.0.0 --open --env.mode development",
     "build": "webpack --env.mode production",
     "lint": "eslint \"src/**/*.js\"",


### PR DESCRIPTION
#### Fixes #3622
#### Changes: 
   Added debugging support for susi.ai in development environment.

#### What I did?
 * I added `devtool : source-map` to webpack configuration using command line arguments.
 * Adding source-maps to bundle can increase webpack building time.
 * To avoid this, I have added a new script `debug` in package.json to give developer an option to run webpack-dev-server with or without source-maps.


Demo Link: https://pr-3623-fossasia-susi-web-chat.surge.sh

#### Screenshots of the change: 
Debugging in vscode with debugger for chrome extension
![Screenshot from 2020-12-23 17-36-30](https://user-images.githubusercontent.com/24855641/102996301-e365e600-4548-11eb-8864-38deb7d42d3f.png)
Debugging with chrome
![Screenshot from 2020-12-23 17-40-29](https://user-images.githubusercontent.com/24855641/102996314-ecef4e00-4548-11eb-8300-1f05a6409734.png)


