### PR TITLE
Admin shows upto 500 entries fixes (#3518)

### DIFF
--- a/src/components/Admin/ListBots/index.js
+++ b/src/components/Admin/ListBots/index.js
@@ -12,6 +12,66 @@ import { Container } from '../AdminStyles';
 import { ActionSpan, ActionSeparator } from '../../shared/TableActionStyles';
 import { deleteChatBot, fetchBots } from '../../../apis/index';
 
+import { forwardRef } from 'react';
+
+import AddBox from '@material-ui/icons/AddBox';
+import ArrowUpward from '@material-ui/icons/ArrowUpward';
+import Check from '@material-ui/icons/Check';
+import ChevronLeft from '@material-ui/icons/ChevronLeft';
+import ChevronRight from '@material-ui/icons/ChevronRight';
+import Clear from '@material-ui/icons/Clear';
+import DeleteOutline from '@material-ui/icons/DeleteOutline';
+import Edit from '@material-ui/icons/Edit';
+import FilterList from '@material-ui/icons/FilterList';
+import FirstPage from '@material-ui/icons/FirstPage';
+import LastPage from '@material-ui/icons/LastPage';
+import Remove from '@material-ui/icons/Remove';
+import SaveAlt from '@material-ui/icons/SaveAlt';
+import Search from '@material-ui/icons/Search';
+import ViewColumn from '@material-ui/icons/ViewColumn';
+
+const tableIcons = {
+  Add: forwardRef((props, ref) => <AddBox {...props} ref={ref} />),
+  Check: forwardRef((props, ref) => <Check {...props} ref={ref} />),
+  Clear: forwardRef((props, ref) => <Clear {...props} ref={ref} />),
+  Delete: forwardRef((props, ref) => <DeleteOutline {...props} ref={ref} />),
+  DetailPanel: forwardRef((props, ref) => {
+    return <ChevronRight {...props} ref={ref} />;
+  }),
+  Edit: forwardRef((props, ref) => <Edit {...props} ref={ref} />),
+  Export: forwardRef((props, ref) => <SaveAlt {...props} ref={ref} />),
+  Filter: forwardRef((props, ref) => <FilterList {...props} ref={ref} />),
+  FirstPage: forwardRef((props, ref) => <FirstPage {...props} ref={ref} />),
+  LastPage: forwardRef((props, ref) => <LastPage {...props} ref={ref} />),
+  NextPage: forwardRef((props, ref) => <ChevronRight {...props} ref={ref} />),
+  PreviousPage: forwardRef((props, ref) => {
+    return <ChevronLeft {...props} ref={ref} />;
+  }),
+  ResetSearch: forwardRef((props, ref) => <Clear {...props} ref={ref} />),
+  Search: forwardRef((props, ref) => <Search {...props} ref={ref} />),
+  SortArrow: forwardRef((props, ref) => <ArrowUpward {...props} ref={ref} />),
+  ThirdStateCheck: forwardRef((props, ref) => <Remove {...props} ref={ref} />),
+  ViewColumn: forwardRef((props, ref) => <ViewColumn {...props} ref={ref} />),
+};
+
+tableIcons.Add.displayName = 'Add';
+tableIcons.Check.displayName = 'Check';
+tableIcons.Clear.displayName = 'Clear';
+tableIcons.Delete.displayName = 'Delete';
+tableIcons.DetailPanel.displayName = 'DetailPanel';
+tableIcons.Edit.displayName = 'Edit';
+tableIcons.Export.displayName = 'Export';
+tableIcons.Filter.displayName = 'Filter';
+tableIcons.FirstPage.displayName = 'FirstPage';
+tableIcons.LastPage.displayName = 'LastPage';
+tableIcons.NextPage.displayName = 'NextPage';
+tableIcons.PreviousPage.displayName = 'PreviousPage';
+tableIcons.ResetSearch.displayName = 'ResetSearch';
+tableIcons.Search.displayName = 'Search';
+tableIcons.SortArrow.displayName = 'SortArrow';
+tableIcons.ThirdStateCheck.displayName = 'ThirdStateCheck';
+tableIcons.ViewColumn.displayName = 'ViewColumn';
+
 class ListBots extends React.Component {
   state = {
     bots: [],
@@ -117,8 +177,10 @@ class ListBots extends React.Component {
             isLoading={loadingBots}
             options={{
               actionsColumnIndex: -1,
-              pageSize: 10,
+              pageSize: 25,
+              pageSizeOptions: [25, 50, 100, 200, 500],
             }}
+            icons={tableIcons}
             columns={BOT}
             data={bots}
             title=""

--- a/src/components/Admin/ListSkills/SkillTable.js
+++ b/src/components/Admin/ListSkills/SkillTable.js
@@ -5,6 +5,66 @@ import MaterialTable from 'material-table';
 import { getColumnConfig } from './constants';
 import { ActionSpan, ActionSeparator } from '../../shared/TableActionStyles';
 
+import { forwardRef } from 'react';
+
+import AddBox from '@material-ui/icons/AddBox';
+import ArrowUpward from '@material-ui/icons/ArrowUpward';
+import Check from '@material-ui/icons/Check';
+import ChevronLeft from '@material-ui/icons/ChevronLeft';
+import ChevronRight from '@material-ui/icons/ChevronRight';
+import Clear from '@material-ui/icons/Clear';
+import DeleteOutline from '@material-ui/icons/DeleteOutline';
+import Edit from '@material-ui/icons/Edit';
+import FilterList from '@material-ui/icons/FilterList';
+import FirstPage from '@material-ui/icons/FirstPage';
+import LastPage from '@material-ui/icons/LastPage';
+import Remove from '@material-ui/icons/Remove';
+import SaveAlt from '@material-ui/icons/SaveAlt';
+import Search from '@material-ui/icons/Search';
+import ViewColumn from '@material-ui/icons/ViewColumn';
+
+const tableIcons = {
+  Add: forwardRef((props, ref) => <AddBox {...props} ref={ref} />),
+  Check: forwardRef((props, ref) => <Check {...props} ref={ref} />),
+  Clear: forwardRef((props, ref) => <Clear {...props} ref={ref} />),
+  Delete: forwardRef((props, ref) => <DeleteOutline {...props} ref={ref} />),
+  DetailPanel: forwardRef((props, ref) => (
+    <ChevronRight {...props} ref={ref} />
+  )),
+  Edit: forwardRef((props, ref) => <Edit {...props} ref={ref} />),
+  Export: forwardRef((props, ref) => <SaveAlt {...props} ref={ref} />),
+  Filter: forwardRef((props, ref) => <FilterList {...props} ref={ref} />),
+  FirstPage: forwardRef((props, ref) => <FirstPage {...props} ref={ref} />),
+  LastPage: forwardRef((props, ref) => <LastPage {...props} ref={ref} />),
+  NextPage: forwardRef((props, ref) => <ChevronRight {...props} ref={ref} />),
+  PreviousPage: forwardRef((props, ref) => (
+    <ChevronLeft {...props} ref={ref} />
+  )),
+  ResetSearch: forwardRef((props, ref) => <Clear {...props} ref={ref} />),
+  Search: forwardRef((props, ref) => <Search {...props} ref={ref} />),
+  SortArrow: forwardRef((props, ref) => <ArrowUpward {...props} ref={ref} />),
+  ThirdStateCheck: forwardRef((props, ref) => <Remove {...props} ref={ref} />),
+  ViewColumn: forwardRef((props, ref) => <ViewColumn {...props} ref={ref} />),
+};
+
+tableIcons.Add.displayName = 'Add';
+tableIcons.Check.displayName = 'Check';
+tableIcons.Clear.displayName = 'Clear';
+tableIcons.Delete.displayName = 'Delete';
+tableIcons.DetailPanel.displayName = 'DetailPanel';
+tableIcons.Edit.displayName = 'Edit';
+tableIcons.Export.displayName = 'Export';
+tableIcons.Filter.displayName = 'Filter';
+tableIcons.FirstPage.displayName = 'FirstPage';
+tableIcons.LastPage.displayName = 'LastPage';
+tableIcons.NextPage.displayName = 'NextPage';
+tableIcons.PreviousPage.displayName = 'PreviousPage';
+tableIcons.ResetSearch.displayName = 'ResetSearch';
+tableIcons.Search.displayName = 'Search';
+tableIcons.SortArrow.displayName = 'SortArrow';
+tableIcons.ThirdStateCheck.displayName = 'ThirdStateCheck';
+tableIcons.ViewColumn.displayName = 'ViewColumn';
+
 const SkillTable = (props) => {
   const { data, groups, loading, handleOpen, handleDelete } = props;
   return (
@@ -13,8 +73,10 @@ const SkillTable = (props) => {
       options={{
         filtering: true,
         actionsColumnIndex: -1,
-        pageSize: 10,
+        pageSize: 25,
+        pageSizeOptions: [25, 50, 100, 200, 500],
       }}
+      icons={tableIcons}
       columns={getColumnConfig(groups)}
       data={data}
       title=""

--- a/src/components/Admin/ListUser/index.js
+++ b/src/components/Admin/ListUser/index.js
@@ -11,9 +11,66 @@ import DevicePanel from './DevicePanel/index';
 import uiActions from '../../../redux/actions/ui';
 import _SearchBar from 'material-ui-search-bar';
 import COLUMNS from './constants';
-import TablePagination from '@material-ui/core/TablePagination';
 import CloseIcon from '@material-ui/icons/Close';
 import { ActionSpan, ActionSeparator } from '../../shared/TableActionStyles';
+import { forwardRef } from 'react';
+import AddBox from '@material-ui/icons/AddBox';
+import ArrowUpward from '@material-ui/icons/ArrowUpward';
+import Check from '@material-ui/icons/Check';
+import ChevronLeft from '@material-ui/icons/ChevronLeft';
+import ChevronRight from '@material-ui/icons/ChevronRight';
+import Clear from '@material-ui/icons/Clear';
+import DeleteOutline from '@material-ui/icons/DeleteOutline';
+import Edit from '@material-ui/icons/Edit';
+import FilterList from '@material-ui/icons/FilterList';
+import FirstPage from '@material-ui/icons/FirstPage';
+import LastPage from '@material-ui/icons/LastPage';
+import Remove from '@material-ui/icons/Remove';
+import SaveAlt from '@material-ui/icons/SaveAlt';
+import Search from '@material-ui/icons/Search';
+import ViewColumn from '@material-ui/icons/ViewColumn';
+
+const tableIcons = {
+  Add: forwardRef((props, ref) => <AddBox {...props} ref={ref} />),
+  Check: forwardRef((props, ref) => <Check {...props} ref={ref} />),
+  Clear: forwardRef((props, ref) => <Clear {...props} ref={ref} />),
+  Delete: forwardRef((props, ref) => <DeleteOutline {...props} ref={ref} />),
+  DetailPanel: forwardRef((props, ref) => (
+    <ChevronRight {...props} ref={ref} />
+  )),
+  Edit: forwardRef((props, ref) => <Edit {...props} ref={ref} />),
+  Export: forwardRef((props, ref) => <SaveAlt {...props} ref={ref} />),
+  Filter: forwardRef((props, ref) => <FilterList {...props} ref={ref} />),
+  FirstPage: forwardRef((props, ref) => <FirstPage {...props} ref={ref} />),
+  LastPage: forwardRef((props, ref) => <LastPage {...props} ref={ref} />),
+  NextPage: forwardRef((props, ref) => <ChevronRight {...props} ref={ref} />),
+  PreviousPage: forwardRef((props, ref) => (
+    <ChevronLeft {...props} ref={ref} />
+  )),
+  ResetSearch: forwardRef((props, ref) => <Clear {...props} ref={ref} />),
+  Search: forwardRef((props, ref) => <Search {...props} ref={ref} />),
+  SortArrow: forwardRef((props, ref) => <ArrowUpward {...props} ref={ref} />),
+  ThirdStateCheck: forwardRef((props, ref) => <Remove {...props} ref={ref} />),
+  ViewColumn: forwardRef((props, ref) => <ViewColumn {...props} ref={ref} />),
+};
+
+tableIcons.Add.displayName = 'Add';
+tableIcons.Check.displayName = 'Check';
+tableIcons.Clear.displayName = 'Clear';
+tableIcons.Delete.displayName = 'Delete';
+tableIcons.DetailPanel.displayName = 'DetailPanel';
+tableIcons.Edit.displayName = 'Edit';
+tableIcons.Export.displayName = 'Export';
+tableIcons.Filter.displayName = 'Filter';
+tableIcons.FirstPage.displayName = 'FirstPage';
+tableIcons.LastPage.displayName = 'LastPage';
+tableIcons.NextPage.displayName = 'NextPage';
+tableIcons.PreviousPage.displayName = 'PreviousPage';
+tableIcons.ResetSearch.displayName = 'ResetSearch';
+tableIcons.Search.displayName = 'Search';
+tableIcons.SortArrow.displayName = 'SortArrow';
+tableIcons.ThirdStateCheck.displayName = 'ThirdStateCheck';
+tableIcons.ViewColumn.displayName = 'ViewColumn';
 
 const SearchBar = styled(_SearchBar)`
   width: 50%;
@@ -204,6 +261,7 @@ class ListUser extends Component {
             return 1;
           });
         }
+
         this.setState({
           data: users,
           loading: false,
@@ -244,7 +302,7 @@ class ListUser extends Component {
   };
 
   render() {
-    const { loading, search, totalUsers, page, data } = this.state;
+    const { loading, search, data } = this.state;
     return (
       <Container style={{ padding: '1rem 0' }}>
         <SearchBar
@@ -260,11 +318,12 @@ class ListUser extends Component {
             actionsColumnIndex: -1,
             pageSize: 50,
             search: false,
-            pageSizeOptions: [50],
+            pageSizeOptions: [25, 50, 100, 200, 500],
           }}
           columns={COLUMNS}
           data={data}
           title=""
+          icons={tableIcons}
           actions={[
             (rowData) => ({
               onEdit: (event, rowData) => {
@@ -294,20 +353,6 @@ class ListUser extends Component {
                   Delete
                 </ActionSpan>
               </React.Fragment>
-            ),
-            Pagination: (e) => (
-              <TablePagination
-                rowsPerPageOptions={[50]}
-                colSpan={3}
-                count={totalUsers || 0}
-                rowsPerPage={50}
-                page={page}
-                onChangePage={this.handleChangePage}
-                style={{ float: 'right' }}
-                SelectProps={{
-                  native: true,
-                }}
-              />
             ),
           }}
           detailPanel={(rowData) => {


### PR DESCRIPTION
#### Fixes #3518

Changes:
- Admin shows now upto 500 entries, available options 25, 50, 100, 200, 500

#### What I did?
- I modified Material Table props to add 25, 50, 100 , 200, 500 entries option
- I imported Material Icons to fix icons not showing issue in the table's pagination

Demo Link: https://pr-3624-fossasia-susi-web-chat.surge.sh

#### Screenshots of the change:
I have used dummy data for the screenshots.

* Users Page
![Screenshot from 2020-12-24 13-00-53](https://user-images.githubusercontent.com/24855641/103075987-bbcb5800-45f2-11eb-81b0-fb9ce495a09e.png)
![Screenshot from 2020-12-24 13-01-56](https://user-images.githubusercontent.com/24855641/103076002-c1c13900-45f2-11eb-9a01-c2c4cb14c7e7.png)
![Screenshot from 2020-12-24 13-02-33](https://user-images.githubusercontent.com/24855641/103076008-c71e8380-45f2-11eb-81fc-fdf2ed422965.png)
* Skills Page
![Screenshot from 2020-12-24 13-03-09](https://user-images.githubusercontent.com/24855641/103076022-cc7bce00-45f2-11eb-8105-b9b0f78cad1f.png)
![Screenshot from 2020-12-24 13-03-43](https://user-images.githubusercontent.com/24855641/103076034-d1408200-45f2-11eb-9913-44b8779e0e26.png)
* Bots Page
![Screenshot from 2020-12-24 13-04-10](https://user-images.githubusercontent.com/24855641/103076043-d6053600-45f2-11eb-868f-493af7e4592c.png)
![Screenshot from 2020-12-24 13-04-21](https://user-images.githubusercontent.com/24855641/103076053-dac9ea00-45f2-11eb-96e7-c657f6b708e2.png)

