### PR TITLE
Automated updation of recaptcha.js during deployment. fixes (#3625)

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -35,6 +35,10 @@ git config user.email "$COMMIT_AUTHOR_EMAIL"
 
 cd repo
 
+# Getting latest version of google recaptcha library
+wget "https://www.google.com/recaptcha/api.js"
+mv api.js public/js/recaptcha.js 
+
 # Actual building and setup of current push or PR.
 yarn install
 yarn build

--- a/surge_deploy.sh
+++ b/surge_deploy.sh
@@ -6,6 +6,8 @@ fi
 
 yarn global add surge
 # Actual building and setup of current push or PR.
+wget "https://www.google.com/recaptcha/api.js"
+mv api.js public/js/recaptcha.js
 yarn install
 yarn build
 rm -rf node_modules/


### PR DESCRIPTION
Fixes #3625 

Changes: 
   - travis.ci updates recaptcha.js during deployment.

What I did:
   - I scripted Travis CI to download recaptch library using wget, rename and move it into public/js/ folder.

Demo Link: https://pr-3626-fossasia-susi-web-chat.surge.sh

Screenshots of the change: 


![Screenshot from 2020-12-25 18-42-23](https://user-images.githubusercontent.com/24855641/103137039-7f2f5780-46eb-11eb-93ba-7459e3d5dda6.png)
I have used `cat public/js/recaptcha.js` in .travis.yml during screenshot to test whether the file is at required location.
This command is removed now and is not part of the pr.
Line 488 will not appear after merge.


