### PR TITLE
Deleting skills not working issue fixed. Fixes(#3517)

### DIFF
--- a/src/components/Admin/ListSkills/SkillTable.js
+++ b/src/components/Admin/ListSkills/SkillTable.js
@@ -110,11 +110,11 @@ const SkillTable = (props) => {
       ]}
       components={{
         // eslint-disable-next-line react/display-name
-        Action: ({ action }) => (
+        Action: (props) => (
           <React.Fragment>
             <ActionSpan
               onClick={(event) => {
-                action.action(props.data).onEdit(event, props.data);
+                props.action.action(props.data).onEdit(event, props.data);
               }}
             >
               Edit
@@ -122,7 +122,7 @@ const SkillTable = (props) => {
             <ActionSeparator> | </ActionSeparator>
             <ActionSpan
               onClick={(event) =>
-                action.action(props.data).onDelete(event, props.data)
+                props.action.action(props.data).onDelete(event, props.data)
               }
             >
               Delete


### PR DESCRIPTION
**Fixes #3517**

#### Changes:
  - Deleting skills is not working for Admins issue fixed  

#### What was wrong?
-   Wrong data was sent to handleDelete action.
-   Data coming from props of Action Component has to be sent to onDelete() but instead data from props of SkillTable component was sent.

#### What I did?
-  I corrected the data source.

Demo Link: https://pr-3628-fossasia-susi-web-chat.surge.sh

**Screenshots of the change:**
I have used dummy data for screenshots.
##### Before:
![Screenshot from 2020-12-27 15-59-49](https://user-images.githubusercontent.com/24855641/103168815-9b063b00-485c-11eb-8750-83da353cfa54.png)

##### After:
![Screenshot from 2020-12-27 15-59-21](https://user-images.githubusercontent.com/24855641/103168819-a6596680-485c-11eb-8c00-834de7f7b12c.png)



