### PR TITLE
Fix sidebar overflow issue on My Skills page

### DIFF
--- a/src/components/cms/BrowseSkill/BrowseSkill.js
+++ b/src/components/cms/BrowseSkill/BrowseSkill.js
@@ -138,10 +138,9 @@ const SidebarItem = styled(MenuItem)`
 `;
 
 const Sidebar = styled.div`
-  width: 15%;
+  width: 250px;
   min-width: 200px;
   max-width: 250px;
-  overflow-x: hidden;
   display: block;
   z-index: 2;
   flex: 1 1 0;

--- a/src/components/cms/BrowseSkill/BrowseSkill.js
+++ b/src/components/cms/BrowseSkill/BrowseSkill.js
@@ -139,6 +139,9 @@ const SidebarItem = styled(MenuItem)`
 
 const Sidebar = styled.div`
   width: 15%;
+  min-width: 200px;
+  max-width: 250px;
+  overflow-x: hidden;
   display: block;
   z-index: 2;
   flex: 1 1 0;


### PR DESCRIPTION
## Description
Fixed sidebar overflow issue on My Skills page.

## Changes Made
- Added min-width and max-width to sidebar
- Prevented horizontal overflow

## Issue
Closes #3645

## Summary by Sourcery

Constrain the My Skills page sidebar width and hide horizontal overflow to prevent layout issues.

Enhancements:
- Add minimum and maximum width constraints to the sidebar component on the My Skills page.
- Hide horizontal overflow on the sidebar to avoid content spilling and horizontal scrolling.